### PR TITLE
Update spec-kit workflow name

### DIFF
--- a/workflows/spec-kit/.ambient/ambient.json
+++ b/workflows/spec-kit/.ambient/ambient.json
@@ -1,5 +1,5 @@
 {
-  "name": "Plan a feature",
+  "name": "Start spec-kit",
   "description": "Spec driven development workflow for feature planning, task breakdown, and implementation.",
   "systemPrompt": "You are a spec-driven development assistant. FIRST TIME SETUP: Before using any slash commands, run `./.specify/scripts/bash/init-workspace.sh` to initialize the workspace (creates symlink to shared artifacts). Create all specification documents in the specs/ directory. Follow the spec-kit methodology: specification → planning → task breakdown → implementation. Use slash commands: /speckit.specify, /speckit.analyze, /speckit.clarify, /speckit.plan, /speckit.tasks, /speckit.implement, /speckit.checklist.",
   "startupPrompt": "Run `./.specify/scripts/bash/init-workspace.sh` to initialize the workspace. Then greet the user warmly, introduce yourself as their Feature planning assistant, list the available slash commands (/speckit.specify, /speckit.analyze, /speckit.clarify, /speckit.plan, /speckit.tasks, /speckit.implement, /speckit.checklist), and inform them to run /speckit.specify {argument: the feature description} to start the process.",


### PR DESCRIPTION
Based on recent discussions, let's update the name of the existing spec-kit workflow to reduce potential confusion with the new Create PRD/RFE workflow.

In the future we may need to introduce the concept of a workflow owner/team/publisher to avoid naming conflicts, but this will work for now.