### PR TITLE
Fix: Remove artifacts/ prefix from slash command paths

### DIFF
--- a/workflows/prd-rfe-workflow/.claude/commands/prd.create.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/prd.create.md
@@ -28,11 +28,11 @@ You MUST proactively invoke the following collaborating agents to ensure high-qu
 Invoke these agents throughout the PRD creation process. Work collaboratively with them to synthesize discovery and requirements into a comprehensive, well-written PRD.
 
 1. **Load Context**:
-   - Read `artifacts/discovery.md` if it exists
-   - Read `artifacts/requirements.md` if it exists
+   - Read `discovery.md` if it exists
+   - Read `requirements.md` if it exists
    - Consider user input from $ARGUMENTS
 
-2. **Create PRD**: Generate `artifacts/prd.md` with comprehensive structure:
+2. **Create PRD**: Generate `prd.md` with comprehensive structure:
 
    ```markdown
    # Product Requirements Document (PRD)
@@ -248,7 +248,7 @@ Invoke these agents throughout the PRD creation process. Work collaboratively wi
    - **Testability**: Requirements can be validated
    - **Consistency**: No contradictions between sections
 
-5. **Create PRD Validation Checklist**: Generate `artifacts/prd-checklist.md`:
+5. **Create PRD Validation Checklist**: Generate `prd-checklist.md`:
 
    ```markdown
    # PRD Quality Checklist

--- a/workflows/prd-rfe-workflow/.claude/commands/prd.discover.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/prd.discover.md
@@ -28,7 +28,7 @@ Invoke these agents at the start of the discovery process to leverage their expe
 
 Given that initial input, do this:
 
-1. **Create Discovery Document**: Generate `artifacts/discovery.md` with the following structure:
+1. **Create Discovery Document**: Generate `discovery.md` with the following structure:
 
    ```markdown
    # Product Discovery: [Product/Feature Name]

--- a/workflows/prd-rfe-workflow/.claude/commands/prd.requirements.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/prd.requirements.md
@@ -28,10 +28,10 @@ You MUST proactively invoke the following collaborating agents to ensure compreh
 Invoke these agents at the start of the requirements gathering process. Work collaboratively with them to create well-structured, research-informed requirements.
 
 1. **Load Context**:
-   - Read `artifacts/discovery.md` if it exists
+   - Read `discovery.md` if it exists
    - Consider user input from $ARGUMENTS
 
-2. **Create Requirements Document**: Generate `artifacts/requirements.md`:
+2. **Create Requirements Document**: Generate `requirements.md`:
 
    ```markdown
    # Product Requirements: [Product/Feature Name]

--- a/workflows/prd-rfe-workflow/.claude/commands/prd.review.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/prd.review.md
@@ -28,12 +28,12 @@ You MUST proactively invoke the following collaborating agents to ensure compreh
 Invoke these agents at the start of the review process. Work collaboratively with them to assess quality, completeness, and feasibility from multiple perspectives.
 
 1. **Load PRD Artifacts**:
-   - Read `artifacts/discovery.md` (if exists)
-   - Read `artifacts/requirements.md` (if exists)
-   - Read `artifacts/prd.md` (required)
+   - Read `discovery.md` (if exists)
+   - Read `requirements.md` (if exists)
+   - Read `prd.md` (required)
    - Consider user input from $ARGUMENTS
 
-2. **Create PRD Review Report**: Generate `artifacts/prd-review-report.md`:
+2. **Create PRD Review Report**: Generate `prd-review-report.md`:
 
    ```markdown
    # PRD Completeness Review Report

--- a/workflows/prd-rfe-workflow/.claude/commands/prd.sources.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/prd.sources.md
@@ -17,10 +17,10 @@ You **MUST** consider the user input before proceeding (if not empty).
 This command generates a comprehensive list of all data sources that informed the PRD creation. It analyzes the PRD document, discovery artifacts, requirements, and any referenced materials to create a complete source attribution list.
 
 1. **Load Context**:
-   - Read `artifacts/prd.md` (required)
-   - Read `artifacts/discovery.md` (if exists)
-   - Read `artifacts/requirements.md` (if exists)
-   - Read `artifacts/prd-review-report.md` (if exists)
+   - Read `prd.md` (required)
+   - Read `discovery.md` (if exists)
+   - Read `requirements.md` (if exists)
+   - Read `prd-review-report.md` (if exists)
    - Scan for any references, citations, or links in these documents
 
 2. **Identify Source Types**:
@@ -76,7 +76,7 @@ This command generates a comprehensive list of all data sources that informed th
    - **Relevance**: What part of the PRD it informed (e.g., "User Research - Pain Points", "Technical Architecture", "Competitive Analysis")
    - **Citation**: How it's referenced in the PRD (if applicable)
 
-4. **Generate Sources Document**: Create `artifacts/prd-sources.md`:
+4. **Generate Sources Document**: Create `prd-sources.md`:
 
    ```markdown
    # PRD Data Sources

--- a/workflows/prd-rfe-workflow/.claude/commands/rfe.breakdown.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/rfe.breakdown.md
@@ -28,7 +28,7 @@ You MUST proactively invoke the following collaborating agents to ensure compreh
 Invoke these agents at the start of the breakdown process. Work collaboratively with them to decompose the PRD into well-scoped, technically feasible RFEs with proper sizing and dependencies.
 
 1. **Load Context**:
-   - Read `artifacts/prd.md`
+   - Read `prd.md`
    - Understand functional requirements, user stories, and features
    - Consider user input from $ARGUMENTS
 
@@ -38,7 +38,7 @@ Invoke these agents at the start of the breakdown process. Work collaboratively 
    - Identify discrete, implementable units of work
    - Group related requirements into logical RFEs
 
-3. **Create RFE Master List**: Generate `artifacts/rfes.md`:
+3. **Create RFE Master List**: Generate `rfes.md`:
 
    ```markdown
    # Request for Enhancement (RFE) List
@@ -136,10 +136,10 @@ Invoke these agents at the start of the breakdown process. Work collaboratively 
    ```
 
 4. **Generate Individual RFE Documents**:
-   - Create `artifacts/rfe-tasks/` directory (if it doesn't exist)
+   - Create `rfe-tasks/` directory (if it doesn't exist)
    - **IMPORTANT**: Create individual RFE files for ALL RFEs identified in the master list, not just a sample
    - **TEMPLATE**: Use the Red Hat RFE format template at `.claude/templates/rfe-template.md` as a guide
-   - For EACH RFE in the breakdown, create `artifacts/rfe-tasks/RFE-XXX-[slug].md` following the template structure:
+   - For EACH RFE in the breakdown, create `rfe-tasks/RFE-XXX-[slug].md` following the template structure:
 
    ```markdown
    # RFE-XXX: [Title]
@@ -295,7 +295,7 @@ Invoke these agents at the start of the breakdown process. Work collaboratively 
    | [Risk 1] | [High/Med/Low] | [How to address] |
    ```
 
-   **CRITICAL**: You MUST create individual RFE files for EVERY RFE identified in the master list. Do not create only a sample file. Each RFE from the master list must have its own corresponding file in the `artifacts/rfe-tasks/` directory.
+   **CRITICAL**: You MUST create individual RFE files for EVERY RFE identified in the master list. Do not create only a sample file. Each RFE from the master list must have its own corresponding file in the `rfe-tasks/` directory.
 
 5. **RFE Breakdown Principles**:
    - **Atomic**: Each RFE should be independently deliverable
@@ -317,11 +317,11 @@ Invoke these agents at the start of the breakdown process. Work collaboratively 
    - Dependencies are acyclic (no circular dependencies)
    - Each RFE has clear acceptance criteria
    - Priorities align with business goals
-   - **VERIFY**: Every RFE in the master list has a corresponding individual file in `artifacts/rfe-tasks/`
+   - **VERIFY**: Every RFE in the master list has a corresponding individual file in `rfe-tasks/`
 
 8. **Report Completion**:
-   - Path to RFE master list (`artifacts/rfes.md`)
-   - Path to individual RFE files directory (`artifacts/rfe-tasks/`)
+   - Path to RFE master list (`rfes.md`)
+   - Path to individual RFE files directory (`rfe-tasks/`)
    - Count of RFEs by priority and size
    - Total estimated effort
    - Dependency summary

--- a/workflows/prd-rfe-workflow/.claude/commands/rfe.prioritize.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/rfe.prioritize.md
@@ -27,8 +27,8 @@ You MUST proactively invoke the following collaborating agents to ensure compreh
 Invoke these agents at the start of the prioritization process. Work collaboratively with them to apply prioritization frameworks, assess business value, and create a realistic implementation roadmap.
 
 1. **Load Context**:
-   - Read `artifacts/rfes.md`
-   - Read `artifacts/prd.md` for business goals and success metrics
+   - Read `rfes.md`
+   - Read `prd.md` for business goals and success metrics
    - Consider user input from $ARGUMENTS for prioritization criteria
 
 2. **Gather Prioritization Input**:
@@ -63,7 +63,7 @@ Invoke these agents at the start of the prioritization process. Work collaborati
    - **Fill-ins**: Low value, low effort (do if time permits)
    - **Money Pit**: Low value, high effort (avoid/defer)
 
-4. **Create Prioritization Document**: Generate `artifacts/prioritization.md`:
+4. **Create Prioritization Document**: Generate `prioritization.md`:
 
    ```markdown
    # RFE Prioritization & Roadmap
@@ -212,7 +212,7 @@ Invoke these agents at the start of the prioritization process. Work collaborati
    - Effort estimates are realistic
    - Risks are identified and addressed
 
-6. **Create Visual Roadmap** (optional): Generate `artifacts/roadmap-visual.md`:
+6. **Create Visual Roadmap** (optional): Generate `roadmap-visual.md`:
 
    ```markdown
    # Visual Roadmap

--- a/workflows/prd-rfe-workflow/.claude/commands/rfe.review.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/rfe.review.md
@@ -29,13 +29,13 @@ You MUST proactively invoke the following collaborating agents to ensure compreh
 Invoke these agents at the start of the review process. Work collaboratively with them to validate technical approach, assess testability, check capacity, and ensure architecture alignment.
 
 1. **Load RFE Artifacts**:
-   - Read `artifacts/rfes.md` (required)
-   - Read individual RFE files from `artifacts/rfe-tasks/*.md`
-   - Read `artifacts/prd.md` for context
-   - Read `artifacts/prioritization.md` (if exists)
+   - Read `rfes.md` (required)
+   - Read individual RFE files from `rfe-tasks/*.md`
+   - Read `prd.md` for context
+   - Read `prioritization.md` (if exists)
    - Consider user input from $ARGUMENTS
 
-2. **Create RFE Technical Review Report**: Generate `artifacts/rfe-review-report.md`:
+2. **Create RFE Technical Review Report**: Generate `rfe-review-report.md`:
 
    ```markdown
    # RFE Technical Feasibility Review Report

--- a/workflows/prd-rfe-workflow/.claude/commands/rfe.speedrun.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/rfe.speedrun.md
@@ -35,7 +35,7 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 1. **Execute Discovery**:
    - Run the discovery phase using the user's initial input
    - Invoke collaborating agents: @parker-product_manager.md, @ryan-ux_researcher.md, @aria-ux_architect.md
-   - Generate `artifacts/discovery.md`
+   - Generate `discovery.md`
    - Make reasonable assumptions when information is missing
    - Only ask questions if critical information is completely absent
 
@@ -49,9 +49,9 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 ### Phase 2: Requirements (`/prd.requirements`)
 
 1. **Execute Requirements Gathering**:
-   - Read `artifacts/discovery.md`
+   - Read `discovery.md`
    - Invoke collaborating agents: @parker-product_manager.md, @ryan-ux_researcher.md, @olivia-product_owner.md, @aria-ux_architect.md
-   - Generate `artifacts/requirements.md`
+   - Generate `requirements.md`
    - Use discovery insights to create requirements
    - Apply MoSCoW prioritization automatically
 
@@ -65,9 +65,9 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 ### Phase 3: PRD Creation (`/prd.create`)
 
 1. **Execute PRD Creation**:
-   - Read `artifacts/discovery.md` and `artifacts/requirements.md`
+   - Read `discovery.md` and `requirements.md`
    - Invoke collaborating agents: @parker-product_manager.md, @ryan-ux_researcher.md, @terry-technical_writer.md, @casey-content_strategist.md
-   - Generate `artifacts/prd.md` and `artifacts/prd-checklist.md`
+   - Generate `prd.md` and `prd-checklist.md`
    - Synthesize all information into comprehensive PRD
    - Make reasonable assumptions for missing details
 
@@ -76,9 +76,9 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 ### Phase 4: PRD Review (`/prd.review`)
 
 1. **Execute PRD Review**:
-   - Read `artifacts/prd.md`
+   - Read `prd.md`
    - Invoke collaborating agents: @steve-ux_designer.md, @aria-ux_architect.md, @olivia-product_owner.md, @archie-architect.md
-   - Generate `artifacts/prd-review-report.md`
+   - Generate `prd-review-report.md`
    - Assess quality, completeness, and feasibility
    - Determine if prototype is needed
 
@@ -93,9 +93,9 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 ### Phase 5: PRD Revision (`/prd.revise`) - Conditional
 
 1. **Only execute if review identified critical issues**:
-   - Read `artifacts/prd-review-report.md`
+   - Read `prd-review-report.md`
    - Invoke collaborating agents: @parker-product_manager.md, @terry-technical_writer.md
-   - Update `artifacts/prd.md` based on review feedback
+   - Update `prd.md` based on review feedback
    - Address all critical issues automatically
    - Make reasonable decisions on non-critical feedback
 
@@ -104,9 +104,9 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 ### Phase 6: RFE Breakdown (`/rfe.breakdown`)
 
 1. **Execute RFE Breakdown**:
-   - Read `artifacts/prd.md`
+   - Read `prd.md`
    - Invoke collaborating agents: @olivia-product_owner.md, @stella-staff_engineer.md, @archie-architect.md, @neil-test_engineer.md
-   - Generate `artifacts/rfes.md` and individual RFE files in `artifacts/rfe-tasks/`
+   - Generate `rfes.md` and individual RFE files in `rfe-tasks/`
    - Break down PRD into implementable RFEs
    - Size RFEs appropriately
    - Identify dependencies automatically
@@ -116,7 +116,7 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 ### Phase 7: RFE Review (`/rfe.review`)
 
 1. **Execute RFE Review**:
-   - Read `artifacts/rfes.md` and RFE files
+   - Read `rfes.md` and RFE files
    - Invoke collaborating agents: @stella-staff_engineer.md, @archie-architect.md, @neil-test_engineer.md, @emma-engineering_manager.md, @olivia-product_owner.md
    - Review all RFEs for technical feasibility, testability, and capacity
    - Assess architecture alignment
@@ -143,10 +143,10 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 ### Phase 9: Prioritization (`/rfe.prioritize`)
 
 1. **Execute Prioritization**:
-   - Read `artifacts/rfes.md` and `artifacts/prd.md`
+   - Read `rfes.md` and `prd.md`
    - Invoke collaborating agents: @parker-product_manager.md, @olivia-product_owner.md, @emma-engineering_manager.md
    - Apply RICE or MoSCoW framework automatically
-   - Generate `artifacts/prioritization.md` and optionally `artifacts/roadmap-visual.md`
+   - Generate `prioritization.md` and optionally `roadmap-visual.md`
    - Create implementation roadmap
 
 2. **Critical Questions (only if needed)**:
@@ -159,12 +159,12 @@ This command automates the entire PRD-RFE workflow from discovery through Jira s
 ### Phase 10: RFE Submission (`/rfe.submit`)
 
 1. **Execute Submission**:
-   - Read `artifacts/rfes.md` and all RFE files
+   - Read `rfes.md` and all RFE files
    - Invoke collaborating agents: @olivia-product_owner.md, @emma-engineering_manager.md, @parker-product_manager.md
    - Check for Jira MCP availability
    - If available: Create Jira tickets automatically
    - If not available: Generate manual submission instructions
-   - Create `artifacts/jira-tickets.md` (if Jira MCP available)
+   - Create `jira-tickets.md` (if Jira MCP available)
 
 2. **No questions** - complete workflow
 

--- a/workflows/prd-rfe-workflow/.claude/commands/rfe.submit.md
+++ b/workflows/prd-rfe-workflow/.claude/commands/rfe.submit.md
@@ -27,9 +27,9 @@ You MUST proactively invoke the following collaborating agents to ensure proper 
 Invoke these agents at the start of the submission process. Work collaboratively with them to ensure tickets are properly structured, prioritized, and assigned.
 
 1. **Load Context**:
-   - Read `artifacts/rfes.md` (RFE master list)
-   - Read all individual RFE files from `artifacts/rfe-tasks/` directory
-   - Check if prioritization document exists (`artifacts/prioritization.md`)
+   - Read `rfes.md` (RFE master list)
+   - Read all individual RFE files from `rfe-tasks/` directory
+   - Check if prioritization document exists (`prioritization.md`)
    - Consider user input from $ARGUMENTS
 
 2. **Check Jira MCP Server Availability**:
@@ -42,7 +42,7 @@ Invoke these agents at the start of the submission process. Work collaboratively
    For each RFE in the master list:
    
    a. **Read RFE File**:
-      - Load `artifacts/rfe-tasks/RFE-XXX-[slug].md`
+      - Load `rfe-tasks/RFE-XXX-[slug].md`
       - Extract key information:
         - RFE ID and title
         - Summary
@@ -78,7 +78,7 @@ Invoke these agents at the start of the submission process. Work collaboratively
    
    e. **Report Ticket Creation**:
       - Document created ticket keys (e.g., PROJ-123, PROJ-124)
-      - Create a mapping file: `artifacts/jira-tickets.md` with:
+      - Create a mapping file: `jira-tickets.md` with:
         ```markdown
         # Jira Ticket Mapping
         
@@ -115,7 +115,7 @@ Invoke these agents at the start of the submission process. Work collaboratively
    
    1. **Open Jira** and navigate to your project board
    
-   2. **For each RFE file** in `artifacts/rfe-tasks/`:
+   2. **For each RFE file** in `rfe-tasks/`:
       
       a. Click "Create" to create a new ticket
       
@@ -150,19 +150,19 @@ Invoke these agents at the start of the submission process. Work collaboratively
       - Use Jira's "Links" feature to connect prerequisite and blocking tickets
    
    4. **Create Epics** (if applicable):
-      - If RFEs are grouped by epic (check `artifacts/rfes.md` for phase/epic groupings)
+      - If RFEs are grouped by epic (check `rfes.md` for phase/epic groupings)
       - Create epic tickets and link related RFE tickets to them
    
    5. **Verify Submission**:
-      - Check that all RFEs from `artifacts/rfes.md` have corresponding Jira tickets
+      - Check that all RFEs from `rfes.md` have corresponding Jira tickets
       - Verify dependencies are properly linked
       - Confirm acceptance criteria are included
    
    ### Quick Reference
    
-   - **Total RFEs**: Check `artifacts/rfes.md` for count
-   - **RFE Files**: `artifacts/rfe-tasks/RFE-*.md`
-   - **Prioritization**: If available, check `artifacts/prioritization.md` for recommended order
+   - **Total RFEs**: Check `rfes.md` for count
+   - **RFE Files**: `rfe-tasks/RFE-*.md`
+   - **Prioritization**: If available, check `prioritization.md` for recommended order
    ```
 
 5. **Validate Submission**:


### PR DESCRIPTION
Fixes #17

## Problem
The slash commands in `.claude/commands/` were using paths like `artifacts/discovery.md`, but the `ambient.json` configuration already sets `workingDirectory` to `/workspace/artifacts`. This caused files to be written to nested paths like `/workspace/artifacts/artifacts/discovery.md`, which prevented them from appearing in the Claude Code UI Artifacts pane.

## Solution
Removed the `artifacts/` prefix from all file paths in the slash command files, so they write directly to the working directory.

## Changes
Updated all 10 command files:
- `prd.create.md`
- `prd.discover.md`
- `prd.requirements.md`
- `prd.review.md`
- `prd.sources.md`
- `rfe.breakdown.md`
- `rfe.prioritize.md`
- `rfe.review.md`
- `rfe.speedrun.md`
- `rfe.submit.md`

Changed paths from:
- `artifacts/discovery.md` → `discovery.md`
- `artifacts/prd.md` → `prd.md`
- `artifacts/rfe-tasks/` → `rfe-tasks/`
- etc.

## Testing
Tested with `/prd.discover` command and confirmed files now write to `/workspace/artifacts/` directly and appear correctly in the UI Artifacts pane.

## Impact
All future slash command executions will now write artifacts to the correct location where they're visible in the Claude Code UI.