### PR TITLE
Fix Backlog Triage workflow name and template path

### DIFF
--- a/.github/workflows/triage-report.yml
+++ b/.github/workflows/triage-report.yml
@@ -1,4 +1,4 @@
-name: Generate Triage Report
+name: Backlog Triage
 
 on:
   schedule:
@@ -162,7 +162,7 @@ jobs:
           from datetime import datetime
 
           # Read template
-          with open('workflows/workflows/triage/templates/report.html', 'r') as f:
+          with open('workflows/triage/templates/report.html', 'r') as f:
               template = f.read()
 
           # Read triaged issues


### PR DESCRIPTION
## Overview

This PR fixes two issues in the Backlog Triage workflow that caused the initial run to fail.

## Issues Fixed

### 1. Workflow Name
- **Changed:**  → 
- **Reason:** Per user request, the workflow should be named "Backlog Triage"

### 2. Template Path
- **Changed:**  → 
- **Reason:** The checkout action puts the repository in the `workflows/` directory, not `workflows/workflows/`

## Root Cause

When the workflow checks out the `ambient-code/workflows` repository:
```yaml
- uses: actions/checkout@v4
  with:
    repository: ambient-code/workflows
    path: workflows
```

The files are placed in:
- ✅ `workflows/triage/templates/report.html` (correct)
- ❌ `workflows/workflows/triage/templates/report.html` (incorrect - doesn't exist)

## Testing

After this fix, the workflow will be able to:
- Read the HTML template successfully
- Generate triage reports
- Run on schedule every Sunday at midnight GMT

## Related

Fixes the failure from workflow run: https://github.com/ambient-code/workflows/actions/runs/21151908870
