### PR TITLE
Fix template path in Backlog Triage workflow

### DIFF
--- a/.github/workflows/triage-report.yml
+++ b/.github/workflows/triage-report.yml
@@ -162,7 +162,7 @@ jobs:
           from datetime import datetime
 
           # Read template
-          with open('workflows/triage/templates/report.html', 'r') as f:
+          with open('workflows/workflows/triage/templates/report.html', 'r') as f:
               template = f.read()
 
           # Read triaged issues


### PR DESCRIPTION
## Problem

The workflow is failing with:
```
FileNotFoundError: [Errno 2] No such file or directory: 'workflows/triage/templates/report.html'
```

## Root Cause

The checkout action uses `path: workflows`, which creates this directory structure:
```
workflows/                          # Root of checked-out repo
└── workflows/                      # The workflows/ directory inside the repo  
    └── triage/                     # The triage workflow
        └── templates/
            └── report.html
```

So the template is at `workflows/workflows/triage/templates/report.html`, not `workflows/triage/templates/report.html`.

## Solution

Changed the template path from:
- ❌ `workflows/triage/templates/report.html`
- ✅ `workflows/workflows/triage/templates/report.html`

## Note

PR #23 incorrectly changed this path from `workflows/workflows/triage/` to `workflows/triage/` based on a misunderstanding of the directory structure. This PR reverts that change.

## Fixes

- https://github.com/ambient-code/workflows/actions/runs/21152110683
