### PR TITLE
Fix workflow-creator skill structure to follow Claude Code requirements

### DIFF
--- a/.claude/skills/workflow-creator/SKILL.md
+++ b/.claude/skills/workflow-creator/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: workflow-creator
+description: Creates production-ready ACP workflows with proper structure, agents, commands, and documentation
+---
+
 # Workflow Creator Skill
 
 You are an expert **Ambient Code Platform (ACP) Workflow Specialist**. Your mission is to guide users through creating custom ACP workflows by generating all necessary files with proper structure, following the template-workflow pattern.


### PR DESCRIPTION
  ## Summary

  Fixed workflow-creator skill to comply with Claude Code's skill discovery requirements.

  ## Changes

  - Moved `.claude/skills/workflow-creator.md` → `.claude/skills/workflow-creator/SKILL.md`
  - Added YAML frontmatter with `name` and `description` fields

  ## Why

  Claude Code requires skills to:
  - Be in a directory with a `SKILL.md` file (uppercase)
  - Include YAML frontmatter for proper discovery

  Without this structure, the skill won't appear in `/skills` command.

  ## Verification

  Run `/skills` to verify the skill is now discoverable.