### PR TITLE
feat(pr-overview): add milestone management phase

### DIFF
--- a/internal-workflows/pr-overview/templates/merge-meeting.md
+++ b/internal-workflows/pr-overview/templates/merge-meeting.md
@@ -1,7 +1,7 @@
 # Merge Meeting — {{REPO}}
 
 **Date:** {{DATE}}
-**Open PRs:** {{TOTAL_PRS}} | **Clean (no blockers):** {{CLEAN_COUNT}}
+**Open PRs:** {{TOTAL_PRS}} | **Clean (no blockers):** {{CLEAN_COUNT}} | **In Merge Queue:** {{MILESTONE_COUNT}}
 
 > PRs ranked by merge readiness — fewest blockers first, then by priority signals and size.
 
@@ -34,6 +34,7 @@
 ## Summary
 
 - **Ready now:** {{CLEAN_COUNT}} PRs with zero blockers
+- **In Merge Queue:** {{MILESTONE_COUNT}} PRs
 - **One blocker away:** {{NEAR_COUNT}} PRs
 - **Needs work:** {{WORK_COUNT}} PRs
 - **Recommend closing:** {{CLOSE_COUNT}} PRs (stale / superseded)


### PR DESCRIPTION
## Summary
- Add Phase 3 (Milestone Management) to the PR review workflow instructions: find/create a "Merge Queue" milestone by title, sync clean PRs into it, and overwrite the description with the full merge meeting report
- Update merge-meeting template with `{{MILESTONE_COUNT}}` in header and summary sections
- No script changes needed — `milestone` field already fetched by `fetch-prs.sh`

## Test plan
- [ ] Run the pr-overview workflow against a repo and verify the "Merge Queue" milestone is created
- [ ] Confirm 0-blocker PRs are added to the milestone and blocker PRs are removed
- [ ] Verify milestone description contains the full report with timestamp
- [ ] Re-run and confirm idempotent sync (no duplicate additions, correct removals)

> Companion PR in platform repo: Gkrumbach07/platform (feat/harden-pr-merge-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)