### PR TITLE
feat(review-queue): cleaner report layout

### DIFF
--- a/internal-workflows/pr-overview/CLAUDE.md
+++ b/internal-workflows/pr-overview/CLAUDE.md
@@ -119,10 +119,13 @@ Note: `review_status = "needs_review"` in `analysis.json` means the sub-agent ha
 Use `templates/review-queue.md`. Sections:
 
 - **Ready for Review** — condensed table, priority ordered
-- **Blocked PRs** — table ordered by last updated (most recent first), limit 50. Each row shows blocker icons (CI, CONFLICT, REVIEW, STALE, OVERLAP) and a short issue snippet (e.g., "CI: e2e failing", "CHANGES_REQUESTED from @bob", "Merge conflicts")
-- **Almost Ready** — PRs close to merge (1 mechanical blocker OR sub-agent verdict of `almost`). Write a short agent-generated blurb per PR: 1-2 sentences of context (what happened in review, what's been addressed), then a "Needs:" line with the one concrete action to unblock
+- **Almost Ready** — PRs close to merge (1 mechanical blocker OR sub-agent verdict of `almost`). For each PR write:
+  - Bullet points summarizing the situation (not one big paragraph)
+  - What's been addressed, what's outstanding
+  - A "Needs:" line with the one concrete action to unblock
+- **Remaining Blocked** — table for PRs with 2+ blockers, ordered by last updated. The Issue column should be bullet points listing each blocker concisely (e.g., "- CI: e2e failing\n- Merge conflicts\n- CHANGES_REQUESTED from @bob"). No blocker icons column.
 - **Recommend Closing** — stale/abandoned PRs
-- **Drafts** — WIP PRs
+- **Drafts** — simple table, no notes column
 - **Summary** — counts by bucket + by type
 
 ## Blocker Checklist

--- a/internal-workflows/pr-overview/templates/review-queue.md
+++ b/internal-workflows/pr-overview/templates/review-queue.md
@@ -11,8 +11,6 @@
 
 ## Ready for Review ({{READY_COUNT}})
 
-> Priority order: bug fixes > features > refactors > docs. Smallest first.
-
 | # | PR | Type | Author | Size | Updated | Action Needed |
 |---|---|---|---|---|---|---|
 {{#each READY_PR_ROWS}}
@@ -21,52 +19,34 @@
 
 ---
 
-## Blocked PRs ({{BLOCKED_COUNT}})
-
-> Ordered by last updated (most recent first). Showing up to 50.
-
-| # | PR | Type | Author | Updated | Blockers | Issue |
-|---|---|---|---|---|---|---|
-{{#each BLOCKED_PR_ROWS}}
-| {{RANK}} | [#{{NUMBER}}]({{URL}}) — {{TITLE}} | {{TYPE}} | {{AUTHOR}} | {{UPDATED}} | {{BLOCKER_ICONS}} | {{ISSUE_SNIPPET}} |
-{{/each}}
-
-<details>
-<summary>Blocker legend</summary>
-
-| Icon | Meaning |
-|------|---------|
-| CI | CI checks failing |
-| CONFLICT | Merge conflicts |
-| REVIEW | Changes requested or unresolved review |
-| STALE | No activity in 30+ days |
-| OVERLAP | Diff overlap with another PR |
-
-</details>
-
----
-
 {{#if ALMOST_READY_ENTRIES}}
 ## Almost Ready ({{NEAR_COUNT}})
-
-> One thing away from merge. Agent-written context for each.
 
 {{#each ALMOST_READY_ENTRIES}}
 **[#{{NUMBER}}]({{URL}}) — {{TITLE}}**
 {{TYPE}} · {{AUTHOR}} · {{SIZE}} · {{UPDATED}}
-{{CONTEXT}}
+
+{{CONTEXT_BULLETS}}
+
 **Needs:** {{WHAT_NEEDED}}
 
+---
+
+{{/each}}
+{{/if}}
+
+## Remaining Blocked ({{BLOCKED_COUNT}})
+
+| # | PR | Type | Author | Updated | Issue |
+|---|---|---|---|---|---|
+{{#each BLOCKED_PR_ROWS}}
+| {{RANK}} | [#{{NUMBER}}]({{URL}}) — {{TITLE}} | {{TYPE}} | {{AUTHOR}} | {{UPDATED}} | {{ISSUE_BULLETS}} |
 {{/each}}
 
 ---
 
-{{/if}}
-
 {{#if RECOMMEND_CLOSE_ENTRIES}}
 ## Recommend Closing ({{CLOSE_COUNT}})
-
-> Abandoned, superseded, or too stale to maintain. Close or ping the author.
 
 | PR | Author | Reason | Last Updated |
 |---|---|---|---|
@@ -81,10 +61,10 @@
 {{#if DRAFT_ROWS}}
 ## Drafts ({{DRAFT_COUNT}})
 
-| PR | Type | Author | Updated | Notes |
-|---|---|---|---|---|
+| PR | Type | Author | Updated |
+|---|---|---|---|
 {{#each DRAFT_ROWS}}
-| [#{{NUMBER}}]({{URL}}) — {{TITLE}} | {{TYPE}} | {{AUTHOR}} | {{UPDATED}} | {{NOTES}} |
+| [#{{NUMBER}}]({{URL}}) — {{TITLE}} | {{TYPE}} | {{AUTHOR}} | {{UPDATED}} |
 {{/each}}
 
 ---
@@ -97,9 +77,8 @@
 |--------|-------|
 | Ready for review | {{READY_COUNT}} |
 | In queue (milestone) | {{MILESTONE_COUNT}} |
-| Almost ready (1 blocker) | {{NEAR_COUNT}} |
-| Blocked (2+ blockers) | {{WORK_COUNT}} |
-| Recommend closing | {{CLOSE_COUNT}} |
+| Almost ready | {{NEAR_COUNT}} |
+| Blocked | {{BLOCKED_COUNT}} |
 | Drafts | {{DRAFT_COUNT}} |
 {{#if FORK_COUNT}}| Fork PRs (need manual review) | {{FORK_COUNT}} |{{/if}}
 | **Total open** | **{{TOTAL_PRS}}** |


### PR DESCRIPTION
## Summary

Cleans up the review queue report based on real output feedback.

- **Almost Ready** — bullet points instead of wall-of-text paragraphs. Moved above blocked PRs since these are more actionable.
- **Remaining Blocked** — renamed from "Blocked PRs". Removed the Blockers column (always showed dashes). Issue column now uses bullet points listing each blocker concisely.
- **Drafts** — simplified, removed Notes column.

## Test plan
- [ ] Run review queue and verify Almost Ready section uses bullet points
- [ ] Verify Remaining Blocked table has no Blockers column, Issue column has bullet points
- [ ] Verify report section order: Ready → Almost Ready → Remaining Blocked → Drafts → Summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)