### PR TITLE
Add ACM observability component repository mappings

### DIFF
--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -1155,7 +1155,7 @@
           "repo_type": "golang",
           "cve_fix_workflow": {
             "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13, backplane-2.10 backplane-2.9, backplane-2.8, backplane-2.7, backplane-2.6"
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13, backplane-2.10, backplane-2.9, backplane-2.8, backplane-2.7, backplane-2.6"
           },
           "test_command": "make test-unit",
           "build_command": "make build",

--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -1206,7 +1206,7 @@
         }
       }
     }
-  }, 
+  },
   "metadata": {
     "description": "Component to repository and branch mappings for CVE fix workflow automation",
     "purpose": "Maps Jira components to GitHub repositories and their branch strategies for automated CVE patching",

--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -887,8 +887,308 @@
           }
         }
       }
+    },
+    "Observability": {
+      "container_to_repo_mapping": {
+        "rhacm2/multicluster-observability-rhel9-operator": "stolostron/multicluster-observability-operator",
+        "rhacm2/acm-multicluster-observability-addon-rhel9": "stolostron/multicluster-observability-addon",
+        "rhacm2/kube-state-metrics-rhel9": "stolostron/kube-state-metrics",
+        "rhacm2/observatorium-rhel9": "stolostron/observatorium",
+        "rhacm2/observatorium-operator-rhel9": "stolostron/observatorium-operator",
+        "rhacm2/thanos-rhel9": "stolostron/thanos",
+        "rhacm2/thanos-receive-controller-rhel9": "stolostron/thanos-receive-controller",
+        "rhacm2/prometheus-alertmanager-rhel9": "stolostron/prometheus-alertmanager",
+        "rhacm2/prometheus-rhel9": "stolostron/prometheus",
+        "rhacm2/prometheus-operator-rhel9": "stolostron/prometheus-operator",
+        "rhacm2/node-exporter-rhel9": "stolostron/node-exporter",
+        "rhacm2/kube-rbac-proxy-rhel9": "stolostron/kube-rbac-proxy",
+        "rhacm2/acm-grafana-rhel9": "stolostron/grafana",
+        "rhacm2/memcached-exporter-rhel9": "stolostron/memcached-exporter"
+      },
+      "repositories": {
+        "stolostron/multicluster-observability-operator": {
+          "github_url": "https://github.com/stolostron/multicluster-observability-operator",
+          "default_branch": "main",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Fix in main, backport to active release branches (release-2.13 through release-2.16)",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "main",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make lint",
+          "build_command": "make build",
+          "notes": "Go project. Run 'go mod tidy' after dependency updates. CI config in .github/workflows/"
+        },
+        "stolostron/multicluster-observability-addon": {
+          "github_url": "https://github.com/stolostron/multicluster-observability-addon",
+          "default_branch": "main",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Fix in main, backport to active release branches (release-2.13 through release-2.16)",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "main",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make lint",
+          "build_command": "make addon",
+          "special_requirements": [
+            "Uses bingo for tool management (.bingo/Variables.mk)",
+            "Different golangci-lint versions per branch (v2.0.2 on release-2.14, v2.5.0 on release-2.16+)",
+            "May require 'replace' directives for transitive dependency issues (e.g., go.opentelemetry.io/contrib/otelconf)"
+          ],
+          "notes": "Go project with OpenTelemetry dependencies. Run 'make deps' to verify go.mod/go.sum completeness."
+        },
+        "stolostron/kube-state-metrics": {
+          "github_url": "https://github.com/stolostron/kube-state-metrics",
+          "default_branch": "main",
+          "active_release_branches": [
+            "release-2.17",
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches only (no main branch used for CVE fixes). Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "notes": "No main branch - work directly on release branches"
+        },
+        "stolostron/observatorium": {
+          "github_url": "https://github.com/stolostron/observatorium",
+          "default_branch": "main",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Fix in main, backport to active release branches (release-2.13 through release-2.16)",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "main",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "special_requirements": [
+            "Uses 'replace' directives in go.mod for dependency pinning",
+            "API compatibility: prometheus/common version upgrades may require code changes (e.g., version.NewCollector removed in v0.63.0)",
+            "Vendor directory excluded in .gitignore - CI runs 'go mod vendor' during build"
+          ],
+          "notes": "Go project. Check main.go for API usage when upgrading prometheus/common or similar packages."
+        },
+        "stolostron/observatorium-operator": {
+          "github_url": "https://github.com/stolostron/observatorium-operator",
+          "default_branch": "main",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Fix in main, backport to active release branches (release-2.13 through release-2.16)",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "main",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "notes": "Go project. Verify dependency usage before applying CVE fixes."
+        },
+        "stolostron/thanos": {
+          "github_url": "https://github.com/stolostron/thanos",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "notes": "Go project. Thanos fork."
+        },
+        "stolostron/thanos-receive-controller": {
+          "github_url": "https://github.com/stolostron/thanos-receive-controller",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches only. Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "special_requirements": [
+            "CI configuration in .github/env (golang-version setting)",
+            "Go version upgrades require updating both go.mod AND .github/env",
+            "golangci-lint must be built with Go version >= project's Go version"
+          ],
+          "notes": "Update .github/env golang-version when upgrading Go version in go.mod"
+        },
+        "stolostron/prometheus-alertmanager": {
+          "github_url": "https://github.com/stolostron/prometheus-alertmanager",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "special_requirements": [
+            "CI configuration in .github/workflows/golangci-lint.yml",
+            "Go version upgrades require updating both go.mod AND .github/workflows/.yml",
+            "golangci-lint version pinning: use 'version: latest' for Go 1.24+ compatibility",
+            "Workflow scope required on GitHub PAT to modify .github/workflows/.yml files"
+          ],
+          "notes": "Update .github/workflows/golangci-lint.yml go-version when upgrading Go version. Use 'version: latest' for golangci-lint."
+        },
+        "stolostron/prometheus": {
+          "github_url": "https://github.com/stolostron/prometheus",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "notes": "Go project. Standard prometheus fork."
+        },
+        "stolostron/prometheus-operator": {
+          "github_url": "https://github.com/stolostron/prometheus-operator",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "notes": "Go project. Kubernetes operator for Prometheus."
+        },
+        "stolostron/node-exporter": {
+          "github_url": "https://github.com/stolostron/node-exporter",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "notes": "Go project. Prometheus node exporter."
+        },
+        "stolostron/kube-rbac-proxy": {
+          "github_url": "https://github.com/stolostron/kube-rbac-proxy",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13",
+            "backplane-2.10",
+            "backplane-2.9",
+            "backplane-2.8",
+            "backplane-2.7",
+            "backplane-2.6"
+          ],
+          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first. Backplane branches (backplane-2.6 through backplane-2.10). Different branch naming pattern from other observability repos.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13, backplane-2.10 backplane-2.9, backplane-2.8, backplane-2.7, backplane-2.6"
+          },
+          "test_command": "make test-unit",
+          "build_command": "make build",
+          "special_requirements": [
+            "Different branch naming: backplane-X.Y in addtion to release-X.Y",
+            "May require k8s.io/klog/v2 compatibility updates when upgrading grpc",
+            "Go version upgrades may be required (e.g., grpc v1.79.3 requires Go 1.24.0)",
+            "Some branches may need downgrading to consistent versions (e.g., backplane-2.9 and 2.10 had grpc v1.80.0, downgraded to v1.79.3 for consistency)"
+          ],
+          "notes": "Older branches (backplane-2.6, 2.7) use Go 1.23-1.24 with grpc v1.56.3. Newer branches (2.9, 2.10) had newer versions but were standardized to v1.79.3."
+        },
+        "stolostron/grafana": {
+          "github_url": "https://github.com/stolostron/grafana",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "notes": "Go project. Grafana fork."
+        }
+      }
     }
-  },
+  }, 
   "metadata": {
     "description": "Component to repository and branch mappings for CVE fix workflow automation",
     "purpose": "Maps Jira components to GitHub repositories and their branch strategies for automated CVE patching",

--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -951,9 +951,8 @@
         },
         "stolostron/kube-state-metrics": {
           "github_url": "https://github.com/stolostron/kube-state-metrics",
-          "default_branch": "main",
+          "default_branch": "release-2.17",
           "active_release_branches": [
-            "release-2.17",
             "release-2.16",
             "release-2.15",
             "release-2.14",
@@ -1185,6 +1184,25 @@
           "test_command": "make test",
           "build_command": "make build",
           "notes": "Go project. Grafana fork."
+        },
+        "stolostron/memcached-exporter": {
+          "github_url": "https://github.com/stolostron/memcached-exporter",
+          "default_branch": "release-2.17",
+          "active_release_branches": [
+            "release-2.16",
+            "release-2.15",
+            "release-2.14",
+            "release-2.13"
+          ],
+          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
+          "repo_type": "golang",
+          "cve_fix_workflow": {
+            "primary_target": "release-2.17",
+            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
+          },
+          "test_command": "make test",
+          "build_command": "make build",
+          "notes": "Go project. Memcached exporter."
         }
       }
     }


### PR DESCRIPTION
Added mappings for observability components to their respective GitHub repositories and branch strategies for CVE fix workflows.

Example CVE Jira from our project https://redhat.atlassian.net/browse/ACM-32577 