### PR TITLE
feat: add Observability, simplified mapping schema, PR labels and Jira ID tracking

### DIFF
--- a/workflows/cve-fixer/.claude/commands/cve.fix.md
+++ b/workflows/cve-fixer/.claude/commands/cve.fix.md
@@ -1173,12 +1173,13 @@ the fix requires additional changes beyond a version bump."
        - Risk assessment table
        - Links to CVE advisories
        - **Jira issue references**: List the extracted Jira issue IDs as plain text WITHOUT hyperlinks
-         - ✅ Correct: `Resolves: RHOAIENG-17794, RHOAIENG-16619, RHOAIENG-16616`
-         - ❌ Wrong: `Resolves: [RHOAIENG-17794](https://redhat.atlassian.net/browse/RHOAIENG-17794)`
-         - ❌ Wrong: `Multiple RHOAIENG issues for CVE-2024-21538 across different release branches`
-         - Do NOT create markdown links for Jira issues
-         - Do NOT use generic descriptions - list the ACTUAL issue IDs
-         - Just list the issue IDs separated by commas
+         - ✅ Correct (plain): `Resolves: RHOAIENG-17794, RHOAIENG-16619`
+         - ✅ Correct (linked): `Resolves: [RHOAIENG-17794](https://redhat.atlassian.net/browse/RHOAIENG-17794)`
+         - ✅ Correct for ACM: `Resolves: ACM-32577, ACM-32578`
+         - ❌ Wrong: `Multiple issues for CVE-2024-21538 across different release branches` (no IDs)
+         - ❌ Wrong: omitting Jira IDs entirely
+         - Always include the actual issue IDs — the dashboard scans PR bodies to correlate
+           PRs with CVEs, so missing IDs break tracking
      - **CREATE** the PR using GitHub CLI (with fallback to GitHub API):
        ```bash
        # Prepare PR body
@@ -1243,7 +1244,14 @@ EOF
        PR_URL=$(gh pr create \
          --base <target-branch> \
          --title "Security: Fix CVE-YYYY-XXXXX (<package-name>)" \
+         --body "$PR_BODY" \
+         --label "cve-fixer-automated" 2>/dev/null || \
+         gh pr create \
+         --base <target-branch> \
+         --title "Security: Fix CVE-YYYY-XXXXX (<package-name>)" \
          --body "$PR_BODY")
+       # Note: --label silently fails if the label doesn't exist in the repo.
+       # The fallback without --label ensures PR is always created.
 
        # Enable automerge if --automerge flag was passed and PR was created successfully
        if [ "$AUTOMERGE" = "true" ] && [ -n "$PR_URL" ] && [ "$PR_URL" != "null" ]; then

--- a/workflows/cve-fixer/.claude/commands/cve.fix.md
+++ b/workflows/cve-fixer/.claude/commands/cve.fix.md
@@ -1173,10 +1173,10 @@ the fix requires additional changes beyond a version bump."
        - Risk assessment table
        - Links to CVE advisories
        - **Jira issue references**: List the extracted Jira issue IDs as plain text WITHOUT hyperlinks
-         - ✅ Correct (plain): `Resolves: RHOAIENG-17794, RHOAIENG-16619`
-         - ✅ Correct (linked): `Resolves: [RHOAIENG-17794](https://redhat.atlassian.net/browse/RHOAIENG-17794)`
-         - ✅ Correct for ACM: `Resolves: ACM-32577, ACM-32578`
-         - ❌ Wrong: `Multiple issues for CVE-2024-21538 across different release branches` (no IDs)
+         - ✅ Correct (plain): `Resolves: PROJ-12345`
+         - ✅ Correct (linked): `Resolves: [PROJ-12345](https://redhat.atlassian.net/browse/PROJ-12345)`
+         - ✅ Multiple issues: `Resolves: PROJ-12345, PROJ-12346` (when the same CVE has multiple tickets)
+         - ❌ Wrong: generic description with no IDs
          - ❌ Wrong: omitting Jira IDs entirely
          - Always include the actual issue IDs — the dashboard scans PR bodies to correlate
            PRs with CVEs, so missing IDs break tracking

--- a/workflows/cve-fixer/.claude/commands/onboard.md
+++ b/workflows/cve-fixer/.claude/commands/onboard.md
@@ -2,10 +2,9 @@
 
 ## Purpose
 
-Guides a team through adding their component and repositories to
-`component-repository-mappings.json` and opens a PR to the CVE fixer
-workflow repository. The Jira component name must exactly match what is
-used in Jira — this is validated against the Jira API during onboarding.
+Guides a team through adding their component to `component-repository-mappings.json`
+and generating `.cve-fix/examples.md` guidance files for each repo. Opens a single PR
+to `ambient-code/workflows` containing both the mapping update and the guidance files.
 
 ## Process
 
@@ -13,28 +12,26 @@ used in Jira — this is validated against the Jira API during onboarding.
 
    Ask the user for the following, one question at a time:
 
-   a. **Jira component name** — must match exactly what appears in Jira
-      (case-sensitive). Example: `"AI Evaluations"`, `"llm-d"`, `"AutoML"`
+   a. **Jira component name** — must match exactly what appears in Jira (case-sensitive).
+      Example: `"AI Evaluations"`, `"llm-d"`, `"AutoML"`
 
-   b. **Repos** — for each repo the user wants to add, collect:
+   b. **Repos** — for each repo:
       - GitHub URL (e.g. `https://github.com/org/repo`)
       - Repo type: `upstream`, `midstream`, or `downstream`
-      - Subcomponent name (optional — only needed if the component has multiple
-        distinct container chains, e.g. `"inference-scheduler"`, `"autoscaler"`)
+      - Subcomponent name (optional — only if this component has multiple distinct
+        container chains, e.g. `"inference-scheduler"`, `"autoscaler"`)
 
-   c. **Container image names** (optional) — the `rhoai/odh-*-rhel9` container
-      images that map to each repo. These can be left empty and added later.
+   Container image names are auto-discovered from Jira in Step 2 — no need to provide them manually.
 
-   Collect all repos before proceeding. Ask: "Do you have more repos to add?
-   (yes/no)" after each repo until the user is done.
+   Ask "Do you have more repos to add? (yes/no)" after each one.
 
-2. **Validate Jira Component Name**
+2. **Validate Jira Component and Auto-discover Container Images**
 
-   Use MCP if available (preferred), otherwise fall back to curl.
-   Follow the same MCP-first pattern as `cve.find`:
-   - Try `ToolSearch: select:mcp__mcp-atlassian__jira_search` first
-   - If found, use it to search: `component = "${COMPONENT_NAME}" AND labels = SecurityTracking`
-   - If not found, fall back to curl:
+   Query Jira to both validate the component name AND extract container image names
+   from `pscomponent:` labels on existing CVE issues. This avoids asking the user
+   to provide container names manually.
+
+   Use MCP if available (`select:mcp__mcp-atlassian__jira_search`), otherwise curl:
 
    ```bash
    JIRA_BASE_URL="https://redhat.atlassian.net"
@@ -45,101 +42,194 @@ used in Jira — this is validated against the Jira API during onboarding.
    RESULT=$(curl -s -X GET --connect-timeout 10 --max-time 15 \
      -H "Authorization: Basic ${AUTH}" \
      -H "Content-Type: application/json" \
-     "${JIRA_BASE_URL}/rest/api/3/search/jql?jql=${ENCODED}&maxResults=1&fields=key,summary")
+     "${JIRA_BASE_URL}/rest/api/3/search/jql?jql=${ENCODED}&maxResults=100&fields=key,summary,labels")
 
    ISSUE_COUNT=$(echo "$RESULT" | jq '.issues | length')
    ```
 
-   - If component returns results → confirmed, proceed
-   - If 0 results → warn user: "No CVE issues found for component
-     '${COMPONENT_NAME}' with SecurityTracking label. The component name
-     must match exactly what Jira uses. Do you want to proceed anyway? (yes/no)"
-   - If Jira credentials not available → skip validation and proceed with a note
+   - 0 results → warn: "No CVE issues found — component name must match Jira exactly. Proceed anyway? (yes/no)"
+   - Credentials unavailable → skip, proceed with a note (containers must be added manually later)
+
+   **Extract container image names from `pscomponent:` labels:**
+
+   ```bash
+   # Each Jira issue has labels like "pscomponent:rhoai/odh-container-rhel9"
+   # Collect all unique container names across all issues
+   DISCOVERED_CONTAINERS=$(echo "$RESULT" | jq -r '
+     .issues[].fields.labels[]
+     | select(startswith("pscomponent:"))
+     | ltrimstr("pscomponent:")
+   ' | sort -u)
+
+   if [ -n "$DISCOVERED_CONTAINERS" ]; then
+     echo "✅ Auto-discovered container images from Jira:"
+     echo "$DISCOVERED_CONTAINERS" | sed 's/^/  - /'
+   else
+     echo "ℹ️  No pscomponent: labels found — containers must be added manually later"
+   fi
+   ```
+
+   Store `DISCOVERED_CONTAINERS` for use in Step 4 to populate the `containers` field
+   on the correct repo entry.
 
 3. **Auto-discover Branch Information**
 
-   For each GitHub repo provided, fetch branch info automatically:
+   For each repo, fetch branch info from GitHub:
 
    ```bash
-   for REPO_URL in "${REPOS[@]}"; do
+   for REPO_URL in "${REPO_URLS[@]}"; do
      REPO_FULL=$(echo "$REPO_URL" | sed 's|https://github.com/||')
 
-     # Verify repo exists
      gh api repos/${REPO_FULL} --jq '.full_name' 2>/dev/null || {
-       echo "⚠️ Repo not found: ${REPO_URL}"
-       continue
+       echo "⚠️ Repo not found: ${REPO_URL}"; continue
      }
 
-     # Get default branch
      DEFAULT_BRANCH=$(gh api repos/${REPO_FULL} --jq '.default_branch')
 
-     # Get active release branches (rhoai-*, release/*, odh-*, stable)
      ACTIVE_BRANCHES=$(gh api repos/${REPO_FULL}/branches --paginate \
        -q '.[].name' 2>/dev/null | \
        grep -E '^(rhoai-[0-9]|release/|odh-[0-9]|stable)' | \
-       sort -V | tail -5)  # keep 5 most recent
+       sort -V | tail -5)
 
-     echo "  ${REPO_FULL}: default=${DEFAULT_BRANCH}, active=[${ACTIVE_BRANCHES}]"
+     echo "${REPO_FULL}: default=${DEFAULT_BRANCH}, active=[${ACTIVE_BRANCHES}]"
    done
    ```
 
-   Show the discovered info to the user and ask for confirmation or corrections.
+   Show discovered info and ask the user to confirm or correct.
 
 4. **Build Mapping Entry**
 
-   Construct the JSON entry following the existing schema:
+   Assign the auto-discovered containers to the correct repos. Containers from Jira
+   typically map to the **downstream** repo (they are built from `red-hat-data-services/*`).
+   For upstream and midstream repos, leave `containers` empty unless the user specifies otherwise.
+
+   ```bash
+   # Match each discovered container to the repo that builds it
+   # Containers from pscomponent: labels belong to the downstream repo
+   for REPO_URL in "${REPO_URLS[@]}"; do
+     REPO_TYPE="${REPO_TYPES[$i]}"
+     if [ "$REPO_TYPE" = "downstream" ]; then
+       REPO_CONTAINERS="$DISCOVERED_CONTAINERS"
+     else
+       REPO_CONTAINERS=""  # upstream/midstream don't build the RHOAI container directly
+     fi
+   done
+   ```
+
+   Construct the simplified JSON entry:
 
    ```json
    {
-     "<COMPONENT_NAME>": {
-       "container_to_repo_mapping": {
-         "<container-image>": "<primary-repo>"
+     "repos": [
+       {
+         "url": "https://github.com/org/upstream-repo",
+         "type": "upstream",
+         "default_branch": "main",
+         "active_branches": ["release-0.6"]
        },
-       "repositories": {
-         "<org/repo>": {
-           "github_url": "https://github.com/<org/repo>",
-           "default_branch": "<branch>",
-           "active_release_branches": ["<branch1>", "<branch2>"],
-           "branch_strategy": "TBD — to be updated by component team",
-           "repo_type": "upstream|midstream|downstream",
-           "subcomponent": "<subcomponent-name>",
-           "cve_fix_workflow": {
-             "primary_target": "<default_branch>",
-             "backport_targets": "<active branches comma-separated>"
-           }
-         }
+       {
+         "url": "https://github.com/org/downstream-repo",
+         "type": "downstream",
+         "default_branch": "main",
+         "active_branches": ["rhoai-3.4"],
+         "containers": ["rhoai/odh-container-rhel9"]
        }
-     }
+     ]
    }
    ```
 
-   - Omit `subcomponent` if the user didn't provide one
-   - Omit `container_to_repo_mapping` entries if no containers were provided
-   - Show the generated JSON to the user and ask: "Does this look correct? (yes/no/edit)"
+   - Containers auto-populated from Jira `pscomponent:` labels on downstream repo
+   - If no containers discovered, omit the field (can be added later)
+   - Omit `subcomponent` if not needed
+   - Show the entry to the user: "Does this look correct? (yes/no/edit)"
 
-5. **Set Up Workflows Repository**
+5. **Generate `.cve-fix/examples.md` Guidance**
 
-   The mapping file lives in `ambient-code/workflows`. Check write access and
-   fork if needed:
+   For each repo, analyze recent CVE fix PRs and generate a `.cve-fix/examples.md`
+   file that teaches the CVE fixer workflow how to create PRs matching this repo's
+   conventions. This follows the same approach as the `/guidance.generate --cve-only`
+   command.
+
+   ```bash
+   for REPO_URL in "${REPO_URLS[@]}"; do
+     REPO_FULL=$(echo "$REPO_URL" | sed 's|https://github.com/||')
+     echo "Analyzing CVE PRs in ${REPO_FULL}..."
+
+     # Fetch recent merged PRs and filter for CVE-related ones
+     CVE_PRS=$(gh pr list --repo "$REPO_FULL" --state merged --limit 100 \
+       --json number,title,headRefName,body,files,mergedAt \
+       --jq '[.[] | select(
+         (.title | test("CVE-[0-9]{4}-[0-9]+|GHSA-|[Ss]ecurity:|fix\\(cve\\)"; "i")) or
+         (.headRefName | test("fix/cve-|dependabot/|renovate/"; "i"))
+       )]' 2>/dev/null)
+
+     CVE_COUNT=$(echo "$CVE_PRS" | jq 'length')
+     echo "  Found ${CVE_COUNT} CVE-related merged PRs"
+
+     # Also check recently closed PRs for rejection patterns
+     CLOSED_PRS=$(gh pr list --repo "$REPO_FULL" --state closed --limit 30 \
+       --json number,title,headRefName,reviews \
+       --jq '[.[] | select(
+         (.title | test("CVE-[0-9]{4}-[0-9]+|GHSA-|[Ss]ecurity:"; "i")) and
+         (.reviews | map(select(.state == "CHANGES_REQUESTED")) | length > 0)
+       )]' 2>/dev/null)
+   done
+   ```
+
+   Extract and synthesize patterns:
+   - **Title conventions**: what format does the repo use?
+   - **Branch naming**: what pattern are fix branches named?
+   - **Files changed together**: which files appear together in CVE fixes?
+   - **Co-upgrade patterns**: when package X is bumped, is Y also bumped?
+   - **PR description patterns**: what sections are consistently included?
+   - **Don'ts**: patterns from rejected/closed PRs
+
+   Generate `.cve-fix/examples.md` for each repo:
+
+   ```markdown
+   <!-- last-analyzed: YYYY-MM-DD | cve-merged: N -->
+
+   ## Titles
+   - <pattern> (N/M merged PRs)
+
+   ## Branches
+   - <pattern> (N/M merged PRs)
+
+   ## Files
+   - <files that change together> (N/M merged PRs)
+
+   ## Co-upgrades
+   - When bumping X, also update Y (N/M merged PRs)
+
+   ## PR Description
+   - <required sections or patterns>
+
+   ## Don'ts
+   - ❌ <pattern from rejected/closed PRs>
+   ```
+
+   If fewer than 3 CVE PRs exist, include:
+
+   ```markdown
+   <!-- Insufficient PR history for full pattern extraction.
+        Update with /guidance.update after more CVE fixes are merged. -->
+   ```
+
+6. **Set Up Workflows Repository**
 
    ```bash
    WORKFLOWS_REPO="ambient-code/workflows"
    FORK_USER=$(gh api user --jq '.login' 2>/dev/null)
 
-   # Check write access
    PUSH_ACCESS=$(gh api repos/${WORKFLOWS_REPO} --jq '.permissions.push' 2>/dev/null)
 
    if [ "$PUSH_ACCESS" = "true" ]; then
-     # Clone directly
      git clone "https://github.com/${WORKFLOWS_REPO}.git" /tmp/workflows-onboard
      REMOTE="origin"
      PR_HEAD_PREFIX=""
    else
-     # Fork the repo
-     echo "No write access to ${WORKFLOWS_REPO} — forking..."
+     echo "No write access — forking ${WORKFLOWS_REPO}..."
      gh repo fork "$WORKFLOWS_REPO" --clone=false 2>/dev/null || true
-
-     # Sync fork with upstream main
      gh repo sync "${FORK_USER}/workflows" --source "$WORKFLOWS_REPO" --branch main
      git clone "https://github.com/${FORK_USER}/workflows.git" /tmp/workflows-onboard
      cd /tmp/workflows-onboard
@@ -149,27 +239,23 @@ used in Jira — this is validated against the Jira API during onboarding.
    fi
    ```
 
-6. **Apply the Mapping Change**
+7. **Apply All Changes**
 
    ```bash
    cd /tmp/workflows-onboard
-   git checkout -b "onboard/${COMPONENT_NAME_SLUG}"
+   BRANCH_NAME="onboard/${COMPONENT_NAME_SLUG}"
+   git checkout -b "$BRANCH_NAME"
 
    MAPPING_FILE="workflows/cve-fixer/component-repository-mappings.json"
 
-   # Write the new component JSON to a temp file first to avoid shell injection
-   # (component names or JSON values may contain quotes, backslashes, or newlines)
+   # Add component to mapping file
    echo "$NEW_COMPONENT_JSON" > /tmp/new_component.json
-
    TODAY=$(date +%Y-%m-%d)
 
    python3 - "$MAPPING_FILE" "$COMPONENT_NAME" /tmp/new_component.json "$TODAY" <<'PYEOF'
    import json, sys
 
-   mapping_file = sys.argv[1]
-   component_name = sys.argv[2]
-   new_component_file = sys.argv[3]
-   today = sys.argv[4]
+   mapping_file, component_name, new_component_file, today = sys.argv[1:]
 
    with open(mapping_file) as f:
        data = json.load(f)
@@ -183,76 +269,77 @@ used in Jira — this is validated against the Jira API during onboarding.
    with open(mapping_file, "w") as f:
        json.dump(data, f, indent=2, ensure_ascii=False)
        f.write("\n")
-
-   print(f"Added component: {component_name}")
    PYEOF
 
    rm -f /tmp/new_component.json
-
-   # Validate JSON
    python3 -m json.tool "$MAPPING_FILE" > /dev/null && echo "✅ JSON valid"
-
    git add "$MAPPING_FILE"
+
+   # Add .cve-fix/examples.md for each repo
+   for i in "${!REPO_URLS[@]}"; do
+     REPO_FULL=$(echo "${REPO_URLS[$i]}" | sed 's|https://github.com/||')
+     EXAMPLES_DIR="workflows/cve-fixer/.cve-fix/$(echo "$REPO_FULL" | tr '/' '-')"
+     mkdir -p "$EXAMPLES_DIR"
+     echo "${GENERATED_EXAMPLES[$i]}" > "${EXAMPLES_DIR}/examples.md"
+     git add "${EXAMPLES_DIR}/examples.md"
+   done
+
    git commit -m "feat: onboard ${COMPONENT_NAME} to CVE fixer workflow
 
-   Add component-to-repository mapping for ${COMPONENT_NAME}:
-   $(echo "${REPOS[@]}" | tr ' ' '\n' | sed 's/^/- /')
+   - Add ${COMPONENT_NAME} to component-repository-mappings.json
+   - Generate .cve-fix/examples.md guidance for each repo
 
    Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>"
-   git push "$REMOTE" "onboard/${COMPONENT_NAME_SLUG}"
+
+   git push "$REMOTE" "$BRANCH_NAME"
    ```
 
-7. **Create Pull Request**
+8. **Create Pull Request**
 
    ```bash
    gh pr create \
      --repo "$WORKFLOWS_REPO" \
      --base main \
-     --head "${PR_HEAD_PREFIX}onboard/${COMPONENT_NAME_SLUG}" \
+     --head "${PR_HEAD_PREFIX}${BRANCH_NAME}" \
      --title "feat: onboard ${COMPONENT_NAME} to CVE fixer workflow" \
-     --body "$(cat <<EOF
-   ## Component Onboarding: ${COMPONENT_NAME}
+     --body "## Component Onboarding: ${COMPONENT_NAME}
 
    ### Jira Component
-   - **Name:** ${COMPONENT_NAME}
-   - **Jira query:** \`component = "${COMPONENT_NAME}" AND summary ~ "CVE*" AND labels = SecurityTracking\`
+   **Name:** ${COMPONENT_NAME}
 
    ### Repositories Added
-   $(for REPO in "${REPOS[@]}"; do echo "- ${REPO}"; done)
+   $(for R in "${REPO_URLS[@]}"; do echo "- ${R}"; done)
 
-   ### Container Mappings
-   $([ -n "${CONTAINERS}" ] && echo "${CONTAINERS}" || echo "None provided yet — to be added once container image names are confirmed.")
+   ### Generated Guidance
+   Created \`.cve-fix/examples.md\` for each repo based on CVE PR history.
+   Repos with fewer than 3 CVE PRs will have minimal guidance — run
+   \`/guidance.update\` after more CVE fixes are merged to improve them.
 
    ### Next Steps for Reviewers
    - [ ] Verify Jira component name matches exactly
-   - [ ] Verify all repo URLs and branch names are correct
-   - [ ] Add container image mappings if missing
+   - [ ] Verify repo URLs and active branch names
+   - [ ] Add container image names if missing
+   - [ ] Review generated examples.md files
 
-   🤖 Generated by CVE Fixer /onboard command
-   EOF
-   )"
-
-   echo "✅ PR created successfully"
-   echo "🔗 Review and merge at: <PR_URL>"
+   🤖 Generated by /onboard"
    ```
 
-8. **Cleanup**
+9. **Cleanup**
 
    ```bash
    rm -rf /tmp/workflows-onboard
    ```
 
-## Usage Examples
+## Usage
 
 ```bash
-/onboard
+/onboard    # fully interactive
 ```
-
-The command is fully interactive — it will guide you through each question.
 
 ## Notes
 
-- The Jira component name is case-sensitive and must match exactly
+- Jira component name is case-sensitive and must match exactly
 - Branch info is auto-discovered from GitHub — review and correct if needed
-- Container image mappings can be added later by re-running `/onboard` or opening a PR directly
-- If you don't have write access to `ambient-code/workflows`, the command will automatically fork the repo and open a PR from your fork
+- Container image names can be added later by editing the mapping or re-running `/onboard`
+- Generated `.cve-fix/examples.md` improves over time — run `/guidance.update` after more CVE PRs are merged
+- Fork of `ambient-code/workflows` is created automatically if you lack write access

--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -1,1145 +1,555 @@
 {
   "components": {
-    "AI Core Dashboard": {
-      "container_to_repo_mapping": {
-        "odh-dashboard-container": "opendatahub-io/odh-dashboard",
-        "rhoai/odh-dashboard-rhel8": "opendatahub-io/odh-dashboard",
-        "rhoai/odh-dashboard-rhel9": "opendatahub-io/odh-dashboard",
-        "rhoai/odh-mod-arch-gen-ai-rhel9": "opendatahub-io/odh-dashboard",
-        "rhoai/odh-mod-arch-model-registry-rhel9": "opendatahub-io/odh-dashboard",
-        "mod-arch-maas": "opendatahub-io/odh-dashboard"
-      },
-      "repositories": {
-        "opendatahub-io/odh-dashboard": {
-          "github_url": "https://github.com/opendatahub-io/odh-dashboard",
-          "default_branch": "main",
-          "protected_branches": [
-            "main",
-            "rhoai-release",
-            "odh-release"
-          ],
-          "active_release_branches": [
-            "v2.29.0-fixes",
-            "v2.28.0-fixes",
-            "v2.27.0-fixes"
-          ],
-          "branch_strategy": "Fix in main → auto-propagates to stable → rhoai (every 2 hours). Manual cherry-pick to release branches during code freeze.",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "Active vX.X.X-fixes branches for released versions",
-            "automation": "Auto-sync every 2 hours (main → stable → rhoai)",
-            "manual_intervention": "Cherry-pick during code freeze or for patch releases"
-          },
-          "repository_type": "monorepo",
-          "monorepo_packages": {
-            "packages/gen-ai": "Builds odh-mod-arch-gen-ai container",
-            "packages/model-registry": "Builds odh-mod-arch-modular-architecture container",
-            "packages/maas": "Builds mod-arch-maas container",
-            "packages/kserve": "KServe UI module",
-            "packages/model-serving": "Model serving UI module"
-          }
-        }
-      }
-    },
     "Model as a Service": {
-      "container_to_repo_mapping": {
-        "rhoai/odh-maas-api-rhel9": "opendatahub-io/models-as-a-service"
-      },
-      "repositories": {
-        "opendatahub-io/models-as-a-service": {
-          "github_url": "https://github.com/opendatahub-io/models-as-a-service",
+      "repos": [
+        {
+          "url": "https://github.com/opendatahub-io/models-as-a-service",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "stable",
             "rhoai",
             "v0.1.x"
           ],
-          "branch_strategy": "Fix in main. stable and rhoai are release snapshots — backport manually as needed. v0.1.x is a separate release branch with independent commits.",
-          "repo_type": "upstream",
+          "containers": [
+            "rhoai/odh-maas-api-rhel9"
+          ],
           "subcomponent": "maas-api",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "stable, rhoai, v0.1.x (manual cherry-pick)"
-          },
           "build_location": "maas-api/"
         },
-        "red-hat-data-services/models-as-a-service": {
-          "github_url": "https://github.com/red-hat-data-services/models-as-a-service",
+        {
+          "url": "https://github.com/red-hat-data-services/models-as-a-service",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.3",
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of upstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
           "subcomponent": "maas-api",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.3, rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          },
           "build_location": "maas-api/"
         }
-      }
-    },
-    "Model Serving": {
-      "container_to_repo_mapping": {
-        "odh-modelmesh-runtime-adapter": "opendatahub-io/modelmesh-runtime-adapter",
-        "rhoai/odh-modelmesh-runtime-adapter-rhel8": "opendatahub-io/modelmesh-runtime-adapter",
-        "rhoai/odh-modelmesh-runtime-adapter-rhel9": "opendatahub-io/modelmesh-runtime-adapter",
-        "odh-model-controller": "opendatahub-io/odh-model-controller",
-        "odh-mm-rest-proxy": "opendatahub-io/odh-model-controller",
-        "rhoai/odh-model-controller-rhel8": "opendatahub-io/odh-model-controller",
-        "rhoai/odh-model-controller-rhel9": "opendatahub-io/odh-model-controller",
-        "rhoai/odh-kserve-controller-rhel9": "opendatahub-io/kserve",
-        "rhoai/odh-kserve-storage-initializer-rhel9": "opendatahub-io/kserve",
-        "rhoai/odh-kserve-agent-rhel9": "opendatahub-io/kserve-agent",
-        "rhoai/odh-kserve-router-rhel9": "opendatahub-io/kserve-router",
-        "rhoai/odh-llm-d-inference-scheduler-rhel9": "opendatahub-io/llm-d-inference-scheduler",
-        "rhoai/odh-modelmesh-serving-controller-rhel8": "opendatahub-io/modelmesh"
-      },
-      "repositories": {
-        "opendatahub-io/modelmesh-runtime-adapter": {
-          "github_url": "https://github.com/opendatahub-io/modelmesh-runtime-adapter",
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          }
-        },
-        "opendatahub-io/odh-model-controller": {
-          "github_url": "https://github.com/opendatahub-io/odh-model-controller",
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          }
-        },
-        "opendatahub-io/kserve": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/kserve"
-        },
-        "opendatahub-io/kserve-agent": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/kserve-agent"
-        },
-        "opendatahub-io/kserve-router": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/kserve-router"
-        },
-        "opendatahub-io/llm-d-inference-scheduler": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/llm-d-inference-scheduler"
-        },
-        "opendatahub-io/modelmesh": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/modelmesh"
-        }
-      }
-    },
-    "Notebooks Images": {
-      "container_to_repo_mapping": {
-        "rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-workbench-codeserver-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-workbench-jupyter-datascience-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-pipeline-runtime-datascience-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-workbench-jupyter-minimal-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-workbench-jupyter-trustyai-py312-rhel9": "opendatahub-io/workbench-images",
-        "rhoai/odh-pipeline-runtime-minimal-py312-rhel9": "opendatahub-io/workbench-images"
-      },
-      "repositories": {
-        "opendatahub-io/workbench-images": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/workbench-images"
-        }
-      }
-    },
-    "AI Pipelines": {
-      "container_to_repo_mapping": {
-        "odh-ml-pipelines-driver-container": "opendatahub-io/data-science-pipelines",
-        "odh-ml-pipelines-api-server-v2-container": "opendatahub-io/data-science-pipelines",
-        "odh-ml-pipelines-launcher-container": "opendatahub-io/data-science-pipelines",
-        "odh-ml-pipelines-persistenceagent-container": "opendatahub-io/data-science-pipelines",
-        "odh-ml-pipelines-scheduledworkflow-container": "opendatahub-io/data-science-pipelines",
-        "odh-ml-pipelines-cache-container": "opendatahub-io/data-science-pipelines",
-        "odh-ml-pipelines-api-server-container": "opendatahub-io/data-science-pipelines",
-        "odh-data-science-pipelines-runtime-container": "opendatahub-io/data-science-pipelines",
-        "odh-data-science-pipelines-runtime-generic-container": "opendatahub-io/data-science-pipelines",
-        "odh-ml-pipelines-viewercontroller-argoworkflow-container": "opendatahub-io/data-science-pipelines",
-        "rhoai/odh-data-science-pipelines-operator-controller-rhel8": "opendatahub-io/data-science-pipelines-operator",
-        "odh-data-science-pipelines-argo-argoexec-container": "argoproj/argo-workflows",
-        "odh-data-science-pipelines-argo-workflowcontroller-container": "argoproj/argo-workflows"
-      },
-      "repositories": {
-        "opendatahub-io/data-science-pipelines": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/data-science-pipelines"
-        },
-        "opendatahub-io/data-science-pipelines-operator": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/data-science-pipelines-operator"
-        },
-        "argoproj/argo-workflows": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "External dependency - not managed by OpenDataHub",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "N/A",
-            "automation": "N/A",
-            "excluded_from_automation": true,
-            "manual_intervention": "Monitor upstream releases and update dependency version"
-          },
-          "notes": "Third-party dependency managed by Argo project. Excluded from automation - track upstream fixes only.",
-          "github_url": "https://github.com/argoproj/argo-workflows"
-        }
-      }
-    },
-    "Notebooks Server": {
-      "container_to_repo_mapping": {
-        "rhoai/odh-notebook-controller-rhel8": "opendatahub-io/kubeflow",
-        "rhoai/odh-kf-notebook-controller-rhel8": "opendatahub-io/kubeflow",
-        "rhoai/odh-kf-notebook-controller-rhel9": "opendatahub-io/kubeflow",
-        "rhoai/odh-notebook-controller-rhel9": "opendatahub-io/kubeflow"
-      },
-      "repositories": {
-        "opendatahub-io/kubeflow": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/kubeflow"
-        }
-      }
-    },
-    "Training Kubeflow": {
-      "container_to_repo_mapping": {
-        "rhoai/odh-training-operator-rhel8": "opendatahub-io/training-operator",
-        "rhoai/odh-training-operator-rhel9": "opendatahub-io/training-operator",
-        "rhoai/odh-notebook-controller-rhel8": "opendatahub-io/notebooks",
-        "rhoai/odh-kf-notebook-controller-rhel8": "opendatahub-io/notebooks",
-        "rhoai/odh-notebook-controller-rhel9": "opendatahub-io/notebooks",
-        "rhoai/odh-kf-notebook-controller-rhel9": "opendatahub-io/notebooks",
-        "rhoai/odh-kuberay-operator-controller-rhel9": "opendatahub-io/kuberay-operator-controller",
-        "rhoai/odh-codeflare-operator-rhel8": "opendatahub-io/codeflare-operator",
-        "rhoai/odh-codeflare-operator-rhel9": "opendatahub-io/codeflare-operator"
-      },
-      "repositories": {
-        "opendatahub-io/training-operator": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/training-operator"
-        },
-        "opendatahub-io/notebooks": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/notebooks"
-        },
-        "opendatahub-io/kuberay-operator-controller": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/kuberay-operator-controller"
-        },
-        "opendatahub-io/codeflare-operator": {
-          "default_branch": "main",
-          "protected_branches": [],
-          "active_release_branches": [],
-          "branch_strategy": "TBD - needs investigation",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "TBD",
-            "automation": "Unknown",
-            "manual_intervention": "Unknown"
-          },
-          "github_url": "https://github.com/opendatahub-io/codeflare-operator"
-        }
-      }
+      ]
     },
     "llm-d": {
-      "container_to_repo_mapping": {
-        "rhoai/odh-llm-d-inference-scheduler-rhel9": "opendatahub-io/llm-d-inference-scheduler",
-        "rhoai/odh-llm-d-routing-sidecar-rhel9": "red-hat-data-services/llm-d-routing-sidecar",
-        "rhoai/odh-workload-variant-autoscaler-controller-rhel9": "opendatahub-io/workload-variant-autoscaler"
-      },
-      "repositories": {
-        "llm-d/llm-d-inference-scheduler": {
-          "github_url": "https://github.com/llm-d/llm-d-inference-scheduler",
+      "repos": [
+        {
+          "url": "https://github.com/llm-d/llm-d-inference-scheduler",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-0.5",
             "release-0.6"
           ],
-          "branch_strategy": "Fix in main. Release branches follow pattern release-X.Y.",
-          "repo_type": "upstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-0.5, release-0.6"
-          },
           "subcomponent": "inference-scheduler"
         },
-        "opendatahub-io/llm-d-inference-scheduler": {
-          "github_url": "https://github.com/opendatahub-io/llm-d-inference-scheduler",
+        {
+          "url": "https://github.com/opendatahub-io/llm-d-inference-scheduler",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-0.2",
             "release-0.3.1",
             "release-v0.4",
             "stable-2.x"
           ],
-          "branch_strategy": "Fork of upstream llm-d/llm-d-inference-scheduler. Synced via sync branches. ODH release branches via Konflux replicator.",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-0.2, release-0.3.1, release-v0.4, stable-2.x"
-          },
+          "containers": [
+            "rhoai/odh-llm-d-inference-scheduler-rhel9"
+          ],
           "subcomponent": "inference-scheduler"
         },
-        "red-hat-data-services/llm-d-inference-scheduler": {
-          "github_url": "https://github.com/red-hat-data-services/llm-d-inference-scheduler",
+        {
+          "url": "https://github.com/red-hat-data-services/llm-d-inference-scheduler",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.3",
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.3, rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          },
           "subcomponent": "inference-scheduler"
         },
-        "red-hat-data-services/llm-d-routing-sidecar": {
-          "github_url": "https://github.com/red-hat-data-services/llm-d-routing-sidecar",
+        {
+          "url": "https://github.com/red-hat-data-services/llm-d-routing-sidecar",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-2.25",
             "rhoai-3.0",
             "rhoai-3.2"
           ],
-          "branch_strategy": "Fork of upstream (now archived). Downstream only — upstream code migrated into llm-d-inference-scheduler. No branches beyond rhoai-3.2.",
-          "repo_type": "downstream",
-          "notes": "Upstream llm-d/llm-d-routing-sidecar is archived; code moved to llm-d-inference-scheduler (cmd/pd_sidecar). This downstream repo may be phased out in future releases.",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-2.25, rhoai-3.0, rhoai-3.2"
-          },
-          "subcomponent": "routing-sidecar"
+          "containers": [
+            "rhoai/odh-llm-d-routing-sidecar-rhel9"
+          ],
+          "subcomponent": "routing-sidecar",
+          "notes": "Upstream llm-d/llm-d-routing-sidecar is archived; code moved to llm-d-inference-scheduler (cmd/pd_sidecar). This downstream repo may be phased out in future releases."
         },
-        "llm-d-incubation/batch-gateway": {
-          "github_url": "https://github.com/llm-d-incubation/batch-gateway",
+        {
+          "url": "https://github.com/llm-d-incubation/batch-gateway",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fix in main. No formal release branching documented.",
-          "repo_type": "upstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          },
+          "active_branches": [],
           "subcomponent": "batch-gateway"
         },
-        "opendatahub-io/batch-gateway": {
-          "github_url": "https://github.com/opendatahub-io/batch-gateway",
+        {
+          "url": "https://github.com/opendatahub-io/batch-gateway",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-v0.5"
           ],
-          "branch_strategy": "Fork of upstream llm-d-incubation/batch-gateway.",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-v0.5"
-          },
           "subcomponent": "batch-gateway"
         },
-        "red-hat-data-services/batch-gateway": {
-          "github_url": "https://github.com/red-hat-data-services/batch-gateway",
+        {
+          "url": "https://github.com/red-hat-data-services/batch-gateway",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          },
           "subcomponent": "batch-gateway"
         },
-        "llm-d/llm-d-workload-variant-autoscaler": {
-          "github_url": "https://github.com/llm-d/llm-d-workload-variant-autoscaler",
+        {
+          "url": "https://github.com/llm-d/llm-d-workload-variant-autoscaler",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-0.4.2"
           ],
-          "branch_strategy": "Fix in main. Release branches follow pattern release-X.Y.Z.",
-          "repo_type": "upstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-0.4.2"
-          },
           "subcomponent": "autoscaler"
         },
-        "opendatahub-io/workload-variant-autoscaler": {
-          "github_url": "https://github.com/opendatahub-io/workload-variant-autoscaler",
+        {
+          "url": "https://github.com/opendatahub-io/workload-variant-autoscaler",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-v0.5"
           ],
-          "branch_strategy": "Fork of upstream llm-d/llm-d-workload-variant-autoscaler. Note: repo name differs from upstream (no llm-d- prefix).",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-v0.5"
-          },
+          "containers": [
+            "rhoai/odh-workload-variant-autoscaler-controller-rhel9"
+          ],
           "subcomponent": "autoscaler"
         },
-        "red-hat-data-services/workload-variant-autoscaler": {
-          "github_url": "https://github.com/red-hat-data-services/workload-variant-autoscaler",
+        {
+          "url": "https://github.com/red-hat-data-services/workload-variant-autoscaler",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          },
           "subcomponent": "autoscaler"
         }
-      }
+      ]
     },
     "AI Evaluations": {
-      "container_to_repo_mapping": {
-        "rhoai/odh-ta-lmes-driver-rhel9": "opendatahub-io/trustyai-service-operator",
-        "rhoai/odh-ta-lmes-job-rhel9": "opendatahub-io/lm-evaluation-harness",
-        "rhoai/odh-trustyai-ragas-lls-provider-dsp-rhel9": "opendatahub-io/llama-stack-provider-ragas",
-        "rhoai/odh-eval-hub-rhel9": "opendatahub-io/eval-hub",
-        "rhoai/odh-trustyai-garak-lls-provider-dsp-rhel9": "opendatahub-io/llama-stack-provider-trustyai-garak"
-      },
-      "repositories": {
-        "eval-hub/eval-hub": {
-          "github_url": "https://github.com/eval-hub/eval-hub",
+      "repos": [
+        {
+          "url": "https://github.com/eval-hub/eval-hub",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fix in main. Feature branches follow pattern feature/name or fix/issue.",
-          "repo_type": "upstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          },
+          "active_branches": [],
           "subcomponent": "eval-hub"
         },
-        "eval-hub/eval-hub-sdk": {
-          "github_url": "https://github.com/eval-hub/eval-hub-sdk",
+        {
+          "url": "https://github.com/eval-hub/eval-hub-sdk",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fix in main.",
-          "repo_type": "upstream",
-          "notes": "No midstream/downstream forks exist yet.",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          },
-          "subcomponent": "eval-hub-sdk"
+          "active_branches": [],
+          "subcomponent": "eval-hub-sdk",
+          "notes": "No midstream/downstream forks exist yet."
         },
-        "eval-hub/eval-hub-contrib": {
-          "github_url": "https://github.com/eval-hub/eval-hub-contrib",
+        {
+          "url": "https://github.com/eval-hub/eval-hub-contrib",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fix in main.",
-          "repo_type": "upstream",
-          "notes": "No midstream/downstream forks exist yet.",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          },
-          "subcomponent": "eval-hub-contrib"
+          "active_branches": [],
+          "subcomponent": "eval-hub-contrib",
+          "notes": "No midstream/downstream forks exist yet."
         },
-        "trustyai-explainability/llama-stack-provider-trustyai-garak": {
-          "github_url": "https://github.com/trustyai-explainability/llama-stack-provider-trustyai-garak",
+        {
+          "url": "https://github.com/trustyai-explainability/llama-stack-provider-trustyai-garak",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fix in main.",
-          "repo_type": "upstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          },
+          "active_branches": [],
           "subcomponent": "trustyai-garak"
         },
-        "trustyai-explainability/trustyai-service-operator": {
-          "github_url": "https://github.com/trustyai-explainability/trustyai-service-operator",
+        {
+          "url": "https://github.com/trustyai-explainability/trustyai-service-operator",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release/1.37.0",
             "release/1.38.0"
           ],
-          "branch_strategy": "Fix in main. Release branches follow pattern release/X.Y.Z.",
-          "repo_type": "upstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release/1.37.0, release/1.38.0"
-          },
           "subcomponent": "trustyai-service-operator"
         },
-        "opendatahub-io/eval-hub": {
-          "github_url": "https://github.com/opendatahub-io/eval-hub",
+        {
+          "url": "https://github.com/opendatahub-io/eval-hub",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release/odh-3.4",
             "stable"
           ],
-          "branch_strategy": "Fork of upstream eval-hub/eval-hub.",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release/odh-3.4, stable"
-          },
+          "containers": [
+            "rhoai/odh-eval-hub-rhel9"
+          ],
           "subcomponent": "eval-hub"
         },
-        "opendatahub-io/lm-evaluation-harness": {
-          "github_url": "https://github.com/opendatahub-io/lm-evaluation-harness",
+        {
+          "url": "https://github.com/opendatahub-io/lm-evaluation-harness",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release/odh-3.3",
             "release/odh-3.4",
             "release/odh-3.4-ea2",
             "release/odh-3.5"
           ],
-          "branch_strategy": "ODH fork. Release branches follow pattern release/odh-X.Y.",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release/odh-3.3, release/odh-3.4, release/odh-3.4-ea2, release/odh-3.5"
-          },
+          "containers": [
+            "rhoai/odh-ta-lmes-job-rhel9"
+          ],
           "subcomponent": "lm-evaluation-harness"
         },
-        "opendatahub-io/llama-stack-provider-trustyai-garak": {
-          "github_url": "https://github.com/opendatahub-io/llama-stack-provider-trustyai-garak",
+        {
+          "url": "https://github.com/opendatahub-io/llama-stack-provider-trustyai-garak",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release/odh-3.4",
             "stable"
           ],
-          "branch_strategy": "Fork of upstream trustyai-explainability/llama-stack-provider-trustyai-garak.",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release/odh-3.4, stable"
-          },
+          "containers": [
+            "rhoai/odh-trustyai-garak-lls-provider-dsp-rhel9"
+          ],
           "subcomponent": "trustyai-garak"
         },
-        "opendatahub-io/trustyai-service-operator": {
-          "github_url": "https://github.com/opendatahub-io/trustyai-service-operator",
+        {
+          "url": "https://github.com/opendatahub-io/trustyai-service-operator",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release/odh-3.3",
             "release/odh-3.4",
             "release/odh-3.4-ea2"
           ],
-          "branch_strategy": "Fork of upstream trustyai-explainability/trustyai-service-operator. Release branches follow pattern release/odh-X.Y.",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release/odh-3.3, release/odh-3.4, release/odh-3.4-ea2"
-          },
+          "containers": [
+            "rhoai/odh-ta-lmes-driver-rhel9"
+          ],
           "subcomponent": "trustyai-service-operator"
         },
-        "red-hat-data-services/eval-hub": {
-          "github_url": "https://github.com/red-hat-data-services/eval-hub",
+        {
+          "url": "https://github.com/red-hat-data-services/eval-hub",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          },
           "subcomponent": "eval-hub"
         },
-        "red-hat-data-services/lm-evaluation-harness": {
-          "github_url": "https://github.com/red-hat-data-services/lm-evaluation-harness",
+        {
+          "url": "https://github.com/red-hat-data-services/lm-evaluation-harness",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.3",
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.3, rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          },
           "subcomponent": "lm-evaluation-harness"
         },
-        "red-hat-data-services/llama-stack-provider-trustyai-garak": {
-          "github_url": "https://github.com/red-hat-data-services/llama-stack-provider-trustyai-garak",
+        {
+          "url": "https://github.com/red-hat-data-services/llama-stack-provider-trustyai-garak",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.3",
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.3, rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          },
           "subcomponent": "trustyai-garak"
         },
-        "red-hat-data-services/trustyai-service-operator": {
-          "github_url": "https://github.com/red-hat-data-services/trustyai-service-operator",
+        {
+          "url": "https://github.com/red-hat-data-services/trustyai-service-operator",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.3",
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.3, rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          },
           "subcomponent": "trustyai-service-operator"
         },
-        "trustyai-explainability/llama-stack-provider-ragas": {
-          "github_url": "https://github.com/trustyai-explainability/llama-stack-provider-ragas",
+        {
+          "url": "https://github.com/trustyai-explainability/llama-stack-provider-ragas",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release/0.4.x",
             "release/0.5.x"
           ],
-          "branch_strategy": "Fix in main. Release branches follow pattern release/X.Y.x.",
-          "repo_type": "upstream",
-          "subcomponent": "trustyai-ragas",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release/0.4.x, release/0.5.x"
-          }
+          "subcomponent": "trustyai-ragas"
         },
-        "opendatahub-io/llama-stack-provider-ragas": {
-          "github_url": "https://github.com/opendatahub-io/llama-stack-provider-ragas",
+        {
+          "url": "https://github.com/opendatahub-io/llama-stack-provider-ragas",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release/odh-3.3",
             "release/odh-3.4-ea2",
             "stable"
           ],
-          "branch_strategy": "Fork of upstream trustyai-explainability/llama-stack-provider-ragas. Release branches follow pattern release/odh-X.Y.",
-          "repo_type": "midstream",
-          "subcomponent": "trustyai-ragas",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release/odh-3.3, release/odh-3.4-ea2, stable"
-          }
+          "containers": [
+            "rhoai/odh-trustyai-ragas-lls-provider-dsp-rhel9"
+          ],
+          "subcomponent": "trustyai-ragas"
         },
-        "red-hat-data-services/llama-stack-provider-ragas": {
-          "github_url": "https://github.com/red-hat-data-services/llama-stack-provider-ragas",
+        {
+          "url": "https://github.com/red-hat-data-services/llama-stack-provider-ragas",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.3",
             "rhoai-3.4",
             "rhoai-3.4-ea.1",
             "rhoai-3.4-ea.2"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "subcomponent": "trustyai-ragas",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.3, rhoai-3.4, rhoai-3.4-ea.1, rhoai-3.4-ea.2"
-          }
+          "subcomponent": "trustyai-ragas"
         }
-      }
+      ]
     },
     "AutoML": {
-      "container_to_repo_mapping": {
-        "managed-open-data-hub/odh-automl-rhel9": "red-hat-data-services/pipelines-components"
-      },
-      "repositories": {
-        "kubeflow/pipelines-components": {
-          "github_url": "https://github.com/kubeflow/pipelines-components",
+      "repos": [
+        {
+          "url": "https://github.com/kubeflow/pipelines-components",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fix in main. No formal release branching documented.",
-          "repo_type": "upstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          }
+          "active_branches": []
         },
-        "opendatahub-io/pipelines-components": {
-          "github_url": "https://github.com/opendatahub-io/pipelines-components",
+        {
+          "url": "https://github.com/opendatahub-io/pipelines-components",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fork of upstream kubeflow/pipelines-components.",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          }
+          "active_branches": []
         },
-        "red-hat-data-services/pipelines-components": {
-          "github_url": "https://github.com/red-hat-data-services/pipelines-components",
+        {
+          "url": "https://github.com/red-hat-data-services/pipelines-components",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.4"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "notes": "Monorepo containing both AutoML (components/automl/) and AutoRAG (components/autorag/) components.",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.4"
-          }
+          "containers": [
+            "managed-open-data-hub/odh-automl-rhel9"
+          ],
+          "notes": "Monorepo containing both AutoML (components/automl/) and AutoRAG (components/autorag/) components."
         }
-      }
+      ]
     },
     "AutoRAG": {
-      "container_to_repo_mapping": {},
-      "repositories": {
-        "kubeflow/pipelines-components": {
-          "github_url": "https://github.com/kubeflow/pipelines-components",
+      "repos": [
+        {
+          "url": "https://github.com/kubeflow/pipelines-components",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fix in main. No formal release branching documented.",
-          "repo_type": "upstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          }
+          "active_branches": []
         },
-        "opendatahub-io/pipelines-components": {
-          "github_url": "https://github.com/opendatahub-io/pipelines-components",
+        {
+          "url": "https://github.com/opendatahub-io/pipelines-components",
+          "type": "midstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Fork of upstream kubeflow/pipelines-components.",
-          "repo_type": "midstream",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "None"
-          }
+          "active_branches": []
         },
-        "red-hat-data-services/pipelines-components": {
-          "github_url": "https://github.com/red-hat-data-services/pipelines-components",
+        {
+          "url": "https://github.com/red-hat-data-services/pipelines-components",
+          "type": "downstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "rhoai-3.4"
           ],
-          "branch_strategy": "Fork of midstream. RHOAI release branches follow pattern rhoai-X.Y.",
-          "repo_type": "downstream",
-          "notes": "Monorepo containing both AutoML (components/automl/) and AutoRAG (components/autorag/) components.",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "rhoai-3.4"
-          }
+          "notes": "Monorepo containing both AutoML (components/automl/) and AutoRAG (components/autorag/) components."
         },
-        "IBM/ai4rag": {
-          "github_url": "https://github.com/IBM/ai4rag",
+        {
+          "url": "https://github.com/IBM/ai4rag",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [],
-          "branch_strategy": "Python package upstream. CVEs in ai4rag manifest as container CVEs in pipelines-components — fix by updating ai4rag version there.",
-          "repo_type": "upstream",
-          "notes": "No containerization — distributed as a Python package. No ODH/RHDS forks exist. Excluded from automation; track upstream releases and update dependency version in pipelines-components.",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "N/A",
-            "excluded_from_automation": true
-          }
+          "active_branches": [],
+          "notes": "No containerization — distributed as a Python package. No ODH/RHDS forks exist. Excluded from automation; track upstream releases and update dependency version in pipelines-components."
         }
-      }
+      ]
     },
     "Observability": {
-      "container_to_repo_mapping": {
-        "rhacm2/multicluster-observability-rhel9-operator": "stolostron/multicluster-observability-operator",
-        "rhacm2/acm-multicluster-observability-addon-rhel9": "stolostron/multicluster-observability-addon",
-        "rhacm2/kube-state-metrics-rhel9": "stolostron/kube-state-metrics",
-        "rhacm2/observatorium-rhel9": "stolostron/observatorium",
-        "rhacm2/observatorium-operator-rhel9": "stolostron/observatorium-operator",
-        "rhacm2/thanos-rhel9": "stolostron/thanos",
-        "rhacm2/thanos-receive-controller-rhel9": "stolostron/thanos-receive-controller",
-        "rhacm2/prometheus-alertmanager-rhel9": "stolostron/prometheus-alertmanager",
-        "rhacm2/prometheus-rhel9": "stolostron/prometheus",
-        "rhacm2/prometheus-operator-rhel9": "stolostron/prometheus-operator",
-        "rhacm2/node-exporter-rhel9": "stolostron/node-exporter",
-        "rhacm2/kube-rbac-proxy-rhel9": "stolostron/kube-rbac-proxy",
-        "rhacm2/acm-grafana-rhel9": "stolostron/grafana",
-        "rhacm2/memcached-exporter-rhel9": "stolostron/memcached-exporter"
-      },
-      "repositories": {
-        "stolostron/multicluster-observability-operator": {
-          "github_url": "https://github.com/stolostron/multicluster-observability-operator",
+      "repos": [
+        {
+          "url": "https://github.com/stolostron/multicluster-observability-operator",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Fix in main, backport to active release branches (release-2.13 through release-2.16)",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make lint",
-          "build_command": "make build",
-          "notes": "Go project. Run 'go mod tidy' after dependency updates. CI config in .github/workflows/"
+          "containers": [
+            "rhacm2/multicluster-observability-rhel9-operator"
+          ]
         },
-        "stolostron/multicluster-observability-addon": {
-          "github_url": "https://github.com/stolostron/multicluster-observability-addon",
+        {
+          "url": "https://github.com/stolostron/multicluster-observability-addon",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Fix in main, backport to active release branches (release-2.13 through release-2.16)",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make lint",
-          "build_command": "make addon",
-          "special_requirements": [
-            "Uses bingo for tool management (.bingo/Variables.mk)",
-            "Different golangci-lint versions per branch (v2.0.2 on release-2.14, v2.5.0 on release-2.16+)",
-            "May require 'replace' directives for transitive dependency issues (e.g., go.opentelemetry.io/contrib/otelconf)"
-          ],
-          "notes": "Go project with OpenTelemetry dependencies. Run 'make deps' to verify go.mod/go.sum completeness."
+          "containers": [
+            "rhacm2/acm-multicluster-observability-addon-rhel9"
+          ]
         },
-        "stolostron/kube-state-metrics": {
-          "github_url": "https://github.com/stolostron/kube-state-metrics",
+        {
+          "url": "https://github.com/stolostron/kube-state-metrics",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches only (no main branch used for CVE fixes). Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "notes": "No main branch - work directly on release branches"
+          "containers": [
+            "rhacm2/kube-state-metrics-rhel9"
+          ]
         },
-        "stolostron/observatorium": {
-          "github_url": "https://github.com/stolostron/observatorium",
+        {
+          "url": "https://github.com/stolostron/observatorium",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Fix in main, backport to active release branches (release-2.13 through release-2.16)",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "special_requirements": [
-            "Uses 'replace' directives in go.mod for dependency pinning",
-            "API compatibility: prometheus/common version upgrades may require code changes (e.g., version.NewCollector removed in v0.63.0)",
-            "Vendor directory excluded in .gitignore - CI runs 'go mod vendor' during build"
-          ],
-          "notes": "Go project. Check main.go for API usage when upgrading prometheus/common or similar packages."
+          "containers": [
+            "rhacm2/observatorium-rhel9"
+          ]
         },
-        "stolostron/observatorium-operator": {
-          "github_url": "https://github.com/stolostron/observatorium-operator",
+        {
+          "url": "https://github.com/stolostron/observatorium-operator",
+          "type": "upstream",
           "default_branch": "main",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Fix in main, backport to active release branches (release-2.13 through release-2.16)",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "main",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "notes": "Go project. Verify dependency usage before applying CVE fixes."
+          "containers": [
+            "rhacm2/observatorium-operator-rhel9"
+          ]
         },
-        "stolostron/thanos": {
-          "github_url": "https://github.com/stolostron/thanos",
+        {
+          "url": "https://github.com/stolostron/thanos",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "notes": "Go project. Thanos fork."
+          "containers": [
+            "rhacm2/thanos-rhel9"
+          ]
         },
-        "stolostron/thanos-receive-controller": {
-          "github_url": "https://github.com/stolostron/thanos-receive-controller",
+        {
+          "url": "https://github.com/stolostron/thanos-receive-controller",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches only. Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "special_requirements": [
-            "CI configuration in .github/env (golang-version setting)",
-            "Go version upgrades require updating both go.mod AND .github/env",
-            "golangci-lint must be built with Go version >= project's Go version"
-          ],
-          "notes": "Update .github/env golang-version when upgrading Go version in go.mod"
+          "containers": [
+            "rhacm2/thanos-receive-controller-rhel9"
+          ]
         },
-        "stolostron/prometheus-alertmanager": {
-          "github_url": "https://github.com/stolostron/prometheus-alertmanager",
+        {
+          "url": "https://github.com/stolostron/prometheus-alertmanager",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "special_requirements": [
-            "CI configuration in .github/workflows/golangci-lint.yml",
-            "Go version upgrades require updating both go.mod AND .github/workflows/.yml",
-            "golangci-lint version pinning: use 'version: latest' for Go 1.24+ compatibility",
-            "Workflow scope required on GitHub PAT to modify .github/workflows/.yml files"
-          ],
-          "notes": "Update .github/workflows/golangci-lint.yml go-version when upgrading Go version. Use 'version: latest' for golangci-lint."
+          "containers": [
+            "rhacm2/prometheus-alertmanager-rhel9"
+          ]
         },
-        "stolostron/prometheus": {
-          "github_url": "https://github.com/stolostron/prometheus",
+        {
+          "url": "https://github.com/stolostron/prometheus",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "notes": "Go project. Standard prometheus fork."
+          "containers": [
+            "rhacm2/prometheus-rhel9"
+          ]
         },
-        "stolostron/prometheus-operator": {
-          "github_url": "https://github.com/stolostron/prometheus-operator",
+        {
+          "url": "https://github.com/stolostron/prometheus-operator",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "notes": "Go project. Kubernetes operator for Prometheus."
+          "containers": [
+            "rhacm2/prometheus-operator-rhel9"
+          ]
         },
-        "stolostron/node-exporter": {
-          "github_url": "https://github.com/stolostron/node-exporter",
+        {
+          "url": "https://github.com/stolostron/node-exporter",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "notes": "Go project. Prometheus node exporter."
+          "containers": [
+            "rhacm2/node-exporter-rhel9"
+          ]
         },
-        "stolostron/kube-rbac-proxy": {
-          "github_url": "https://github.com/stolostron/kube-rbac-proxy",
+        {
+          "url": "https://github.com/stolostron/kube-rbac-proxy",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
@@ -1150,66 +560,44 @@
             "backplane-2.7",
             "backplane-2.6"
           ],
-          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first. Backplane branches (backplane-2.6 through backplane-2.10). Different branch naming pattern from other observability repos.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13, backplane-2.10, backplane-2.9, backplane-2.8, backplane-2.7, backplane-2.6"
-          },
-          "test_command": "make test-unit",
-          "build_command": "make build",
-          "special_requirements": [
-            "Different branch naming: backplane-X.Y in addtion to release-X.Y",
-            "May require k8s.io/klog/v2 compatibility updates when upgrading grpc",
-            "Go version upgrades may be required (e.g., grpc v1.79.3 requires Go 1.24.0)",
-            "Some branches may need downgrading to consistent versions (e.g., backplane-2.9 and 2.10 had grpc v1.80.0, downgraded to v1.79.3 for consistency)"
-          ],
-          "notes": "Older branches (backplane-2.6, 2.7) use Go 1.23-1.24 with grpc v1.56.3. Newer branches (2.9, 2.10) had newer versions but were standardized to v1.79.3."
+          "containers": [
+            "rhacm2/kube-rbac-proxy-rhel9"
+          ]
         },
-        "stolostron/grafana": {
-          "github_url": "https://github.com/stolostron/grafana",
+        {
+          "url": "https://github.com/stolostron/grafana",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "notes": "Go project. Grafana fork."
+          "containers": [
+            "rhacm2/acm-grafana-rhel9"
+          ]
         },
-        "stolostron/memcached-exporter": {
-          "github_url": "https://github.com/stolostron/memcached-exporter",
+        {
+          "url": "https://github.com/stolostron/memcached-exporter",
+          "type": "upstream",
           "default_branch": "release-2.17",
-          "active_release_branches": [
+          "active_branches": [
             "release-2.16",
             "release-2.15",
             "release-2.14",
             "release-2.13"
           ],
-          "branch_strategy": "Release branches (release-2.13 through release-2.17). Fix in latest release branch first.",
-          "repo_type": "golang",
-          "cve_fix_workflow": {
-            "primary_target": "release-2.17",
-            "backport_targets": "release-2.16, release-2.15, release-2.14, release-2.13"
-          },
-          "test_command": "make test",
-          "build_command": "make build",
-          "notes": "Go project. Memcached exporter."
+          "containers": [
+            "rhacm2/memcached-exporter-rhel9"
+          ]
         }
-      }
+      ]
     }
   },
   "metadata": {
     "description": "Component to repository and branch mappings for CVE fix workflow automation",
     "purpose": "Maps Jira components to GitHub repositories and their branch strategies for automated CVE patching",
-    "last_updated": "2026-03-29"
+    "last_updated": "2026-04-16"
   }
 }


### PR DESCRIPTION
## Summary

### Simplified mapping schema (from PR #108)
Applies the simplified `repos[]` schema replacing the old nested `repositories` + `container_to_repo_mapping` structure. Removes 6 unused components (AI Core Dashboard, Model Serving, Notebooks Images, AI Pipelines, Notebooks Server, Training Kubeflow). Fixes repo types: `opendatahub-io/*` → midstream, `red-hat-data-services/*` → downstream.

### Observability component (from PR #103)
Converts the Observability component (14 stolostron repos) from the old schema to the simplified format. Containers assigned to their respective repos.

### PR label for dashboard tracking
Every fix PR now gets `--label cve-fixer-automated` so the dashboard can query all workflow-created PRs with `gh pr list --label cve-fixer-automated`. Falls back gracefully if the label doesn't exist in the target repo.

### Jira IDs in PR body
Clarified that both plain (`PROJ-12345`) and linked (`[PROJ-12345](url)`) formats are acceptable. Added note that IDs are required for dashboard tracking.

## Test plan
- [ ] Run `/cve.find Observability` — verify it queries ACM Jira tickets
- [ ] Run `/cve.fix` — verify PRs get `cve-fixer-automated` label
- [ ] Verify PR body includes Jira issue IDs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)