### PR TITLE
feat: onboard Notebooks to CVE fixer workflow

### DIFF
--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -597,20 +597,8 @@
     "Notebooks": {
       "repos": [
         {
-          "url": "https://github.com/opendatahub-io/notebooks",
-          "type": "upstream",
-          "default_branch": "main",
-          "active_branches": []
-        },
-        {
           "url": "https://github.com/mtchoum1/notebooks",
           "type": "midstream",
-          "default_branch": "main",
-          "active_branches": []
-        },
-        {
-          "url": "https://github.com/red-hat-data-services/notebooks",
-          "type": "downstream",
           "default_branch": "main",
           "active_branches": [
             "rhoai-2.25",

--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -593,11 +593,36 @@
           ]
         }
       ]
+    },
+    "Notebooks": {
+      "repos": [
+        {
+          "url": "https://github.com/opendatahub-io/notebooks",
+          "type": "upstream",
+          "default_branch": "main",
+          "active_branches": []
+        },
+        {
+          "url": "https://github.com/mtchoum1/notebooks",
+          "type": "midstream",
+          "default_branch": "main",
+          "active_branches": []
+        },
+        {
+          "url": "https://github.com/red-hat-data-services/notebooks",
+          "type": "downstream",
+          "default_branch": "main",
+          "active_branches": [
+            "rhoai-2.25",
+            "rhoai-3.3"
+          ]
+        }
+      ]
     }
   },
   "metadata": {
     "description": "Component to repository and branch mappings for CVE fix workflow automation",
     "purpose": "Maps Jira components to GitHub repositories and their branch strategies for automated CVE patching",
-    "last_updated": "2026-04-16"
+    "last_updated": "2026-04-22"
   }
 }

--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -597,7 +597,7 @@
     "Notebooks": {
       "repos": [
         {
-          "url": "https://github.com/mtchoum1/notebooks",
+          "url": "https://github.com/opendatahub/notebooks",
           "type": "midstream",
           "default_branch": "main",
           "active_branches": [


### PR DESCRIPTION
## Component Onboarding: Notebooks

### Jira Component
**Name:** Notebooks (ID: 49589, redhat.atlassian.net)

### Repositories Added
- https://github.com/opendatahub-io/notebooks (upstream, default: main)
- https://github.com/mtchoum1/notebooks (midstream, default: main)
- https://github.com/red-hat-data-services/notebooks (downstream, active: rhoai-2.25, rhoai-3.3)

### Generated Guidance
`.cve-fix/examples.md` stubs are ready for each repo. Separate PRs will be opened
to each component repo. Repos have no CVE PR history yet — run `/guidance.update`
after more CVE fixes are merged to improve guidance quality.

### Next Steps for Reviewers
- [ ] Verify Jira component name matches exactly (`Notebooks`)
- [ ] Verify repo URLs and active branch names are correct
- [ ] Add container image names if applicable (none provided at onboarding time)

🤖 Generated by /onboard