### PR TITLE
fix: remove stable from active branches for models-as-a-service

### DIFF
--- a/workflows/cve-fixer/component-repository-mappings.json
+++ b/workflows/cve-fixer/component-repository-mappings.json
@@ -7,7 +7,6 @@
           "type": "midstream",
           "default_branch": "main",
           "active_branches": [
-            "stable",
             "rhoai",
             "v0.1.x"
           ],


### PR DESCRIPTION
## Summary
- Remove `stable` from `active_branches` for `opendatahub-io/models-as-a-service` in the CVE fixer component mapping
- The `stable` branch is no longer actively used upstream — dependency bumps (Dependabot) and CVE fixes already land on `main` and `v0.1.x`

## Test plan
- [ ] Verify JSON is valid
- [ ] Run CVE fixer workflow against models-as-a-service to confirm it no longer targets `stable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)